### PR TITLE
Update tab and property names part 4

### DIFF
--- a/src/Foundation.Cms/Pages/CalendarEventPage.cs
+++ b/src/Foundation.Cms/Pages/CalendarEventPage.cs
@@ -11,11 +11,11 @@ namespace Foundation.Cms.Pages
     {
         [CultureSpecific]
         [Display(Name = "Start date", GroupName = SystemTabNames.Content, Order = 10)]
-        public virtual DateTime StartDate { get; set; }
+        public virtual DateTime EventStartDate { get; set; }
 
         [CultureSpecific]
         [Display(Name = "End date", GroupName = SystemTabNames.Content, Order = 20)]
-        public virtual DateTime EndDate { get; set; }
+        public virtual DateTime EventEndDate { get; set; }
 
         [CultureSpecific]
         [Display(GroupName = SystemTabNames.Content, Order = 30)]

--- a/src/Foundation/Features/Events/CalendarEvent/Index.cshtml
+++ b/src/Foundation/Features/Events/CalendarEvent/Index.cshtml
@@ -8,16 +8,16 @@
 <div class="row">
     <div class="col-12">
         <strong>Start Date: </strong>
-        <div class="date-heading-section" @Html.EditAttributes(m => m.CurrentContent.StartDate)>
-            @Model.CurrentContent.StartDate.ToString("MMMM-dd-yyyy HH:mm tt")
+        <div class="date-heading-section" @Html.EditAttributes(m => m.CurrentContent.EventStartDate)>
+            @Model.CurrentContent.EventStartDate.ToString("MMMM-dd-yyyy HH:mm tt")
         </div>
     </div>
 </div>
 <div class="row">
     <div class="col-12">
         <strong>End Date: </strong>
-        <div class="date-heading-section" @Html.EditAttributes(m => m.CurrentContent.EndDate)>
-            @Model.CurrentContent.EndDate.ToString("MMMM-dd-yyyy HH:mm tt")
+        <div class="date-heading-section" @Html.EditAttributes(m => m.CurrentContent.EventEndDate)>
+            @Model.CurrentContent.EventEndDate.ToString("MMMM-dd-yyyy HH:mm tt")
         </div>
     </div>
 </div>


### PR DESCRIPTION
Commerce language file overrides the display name of 2 properties StartDate and EndDate. 2 properties need to be changed to avoid overriding.