### PR TITLE
#112: Add Associations tab to product detail page

### DIFF
--- a/src/Foundation.Commerce/Catalog/ProductService.cs
+++ b/src/Foundation.Commerce/Catalog/ProductService.cs
@@ -33,6 +33,7 @@ namespace Foundation.Commerce.Catalog
         private readonly LanguageService _languageService;
         private readonly FilterPublished _filterPublished;
         private readonly IStoreService _storeService;
+        private readonly ICurrentMarket _currentMarket;
 
         public ProductService(IContentLoader contentLoader,
             IPromotionService promotionService,
@@ -44,7 +45,8 @@ namespace Foundation.Commerce.Catalog
             ReferenceConverter referenceConverter,
             LanguageService languageService,
             FilterPublished filterPublished,
-            IStoreService storeService)
+            IStoreService storeService,
+            ICurrentMarket currentMarket)
         {
             _contentLoader = contentLoader;
             _promotionService = promotionService;
@@ -58,6 +60,7 @@ namespace Foundation.Commerce.Catalog
             _languageService = languageService;
             _filterPublished = filterPublished;
             _storeService = storeService;
+            _currentMarket = currentMarket;
         }
 
         public IEnumerable<VariationContent> GetVariants(ProductContent currentContent) => GetAvailableVariants(currentContent.GetVariants(_relationRepository));
@@ -88,7 +91,7 @@ namespace Foundation.Commerce.Catalog
         {
             var language = _languageService.GetCurrentLanguage();
             var contentItems = _contentLoader.GetItems(entryLinks, language);
-            return contentItems.OfType<EntryContentBase>().Select(GetProductTileViewModel);
+            return contentItems.OfType<EntryContentBase>().Select(x => x.GetProductTileViewModel(_currentMarket.GetCurrentMarket(), _currencyService.GetCurrentCurrency()));
         }
 
         public virtual ProductTileViewModel GetProductTileViewModel(EntryContentBase entry)

--- a/src/Foundation.Commerce/Models/Catalog/GenericBundle.cs
+++ b/src/Foundation.Commerce/Models/Catalog/GenericBundle.cs
@@ -19,33 +19,42 @@ namespace Foundation.Commerce.Models.Catalog
         [CultureSpecific]
         [Tokenize]
         [IncludeInDefaultSearch]
-        [Display(Name = "Description", Order = 1)]
+        [Display(Name = "Description", Order = 5)]
         public virtual XhtmlString Description { get; set; }
 
         [Searchable]
         [CultureSpecific]
         [Tokenize]
         [IncludeInDefaultSearch]
-        [Display(Name = "Long Description", Order = 3)]
+        [Display(Name = "Long description", Order = 10)]
         public virtual XhtmlString LongDescription { get; set; }
 
-        [Display(Name = "On Sale", Order = 2, Description = "Is on sale?")]
+        [Display(Name = "On sale", Description = "Is on sale?", Order = 15)]
         public virtual bool OnSale { get; set; }
 
-        [Display(Name = "New Arrival", Order = 2, Description = "Is on a new arrival?")]
+        [Display(Name = "New arrival", Description = "Is on a new arrival?", Order = 20)]
         public virtual bool NewArrival { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Content Area", Order = 3, Description = "This will display the content area.")]
+        [Display(Name = "Content area", Description = "This will display the content area.", Order = 25)]
         public virtual ContentArea ContentArea { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Show Recommendations", Order = 50, Description = "This will determine whether or not to show recommendations.")]
+        [Display(Name = "Associations title",
+            Description = "This is title of the Associations tab.",
+            Order = 30)]
+        public virtual string AssociationsTitle { get; set; }
+
+        [CultureSpecific]
+        [Display(Name = "Show recommendations", Description = "This will determine whether or not to show recommendations.", Order = 35)]
         public virtual bool ShowRecommendations { get; set; }
 
         public override void SetDefaultValues(ContentType contentType)
         {
+            base.SetDefaultValues(contentType);
+
             ShowRecommendations = true;
+            AssociationsTitle = "You May Also Like";
         }
     }
 }

--- a/src/Foundation.Commerce/Models/Catalog/GenericNode.cs
+++ b/src/Foundation.Commerce/Models/Catalog/GenericNode.cs
@@ -11,19 +11,19 @@ namespace Foundation.Commerce.Models.Catalog
     public class GenericNode : NodeContent, IProductRecommendations
     {
         [CultureSpecific]
-        [Display(Name = "LongName", GroupName = SystemTabNames.Content)]
+        [Display(Name = "Long name", GroupName = SystemTabNames.Content, Order = 5)]
         [BackingType(typeof(PropertyString))]
         public virtual string LongName { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Teaser", GroupName = SystemTabNames.Content)]
+        [Display(Name = "Teaser", GroupName = SystemTabNames.Content, Order = 10)]
         public virtual string Teaser { get; set; }
 
         [Searchable]
         [CultureSpecific]
         [Tokenize]
         [IncludeInDefaultSearch]
-        [Display(Name = "Description", GroupName = SystemTabNames.Content)]
+        [Display(Name = "Description", GroupName = SystemTabNames.Content, Order = 15)]
         public virtual XhtmlString Description { get; set; }
 
         [CultureSpecific]
@@ -31,15 +31,14 @@ namespace Foundation.Commerce.Models.Catalog
             Name = "Top content area",
             Description = "",
             GroupName = SystemTabNames.Content,
-            Order = 4)]
+            Order = 20)]
         public virtual ContentArea TopContentArea { get; set; }
 
-        [Display(Name = "Partial page size", Order = 1)]
+        [Display(Name = "Partial page size", Order = 25)]
         public virtual int PartialPageSize { get; set; }
 
-
         [CultureSpecific]
-        [Display(Name = "Show Recommendations", Order = 50, Description = "This will determine whether or not to show recommendations.")]
+        [Display(Name = "Show recommendations", Description = "This will determine whether or not to show recommendations.", Order = 30)]
         public virtual bool ShowRecommendations { get; set; }
 
         public override void SetDefaultValues(ContentType contentType) => ShowRecommendations = true;

--- a/src/Foundation.Commerce/Models/Catalog/GenericPackage.cs
+++ b/src/Foundation.Commerce/Models/Catalog/GenericPackage.cs
@@ -1,6 +1,7 @@
 ﻿using EPiServer.Commerce.Catalog.ContentTypes;
 using EPiServer.Commerce.Catalog.DataAnnotations;
 using EPiServer.Core;
+using EPiServer.DataAbstraction;
 using EPiServer.DataAnnotations;
 using System.ComponentModel.DataAnnotations;
 
@@ -13,32 +14,44 @@ namespace Foundation.Commerce.Models.Catalog
         [CultureSpecific]
         [Tokenize]
         [IncludeInDefaultSearch]
-        [Display(Name = "Description", Order = 1)]
+        [Display(Name = "Description", Order = 5)]
         public virtual XhtmlString Description { get; set; }
 
-        [Display(Name = "On Sale", Order = 2, Description = "Is on sale?")]
+        [Display(Name = "On sale", Description = "Is on sale?", Order = 10)]
         public virtual bool OnSale { get; set; }
 
-        [Display(Name = "New Arrival", Order = 2, Description = "Is on a new arroval?")]
+        [Display(Name = "New arrival", Description = "Is on a new arroval?", Order = 15)]
         public virtual bool NewArrival { get; set; }
 
         [Searchable]
         [CultureSpecific]
         [Tokenize]
         [IncludeInDefaultSearch]
-        [Display(Name = "Long Description", Order = 3)]
+        [Display(Name = "Long description", Order = 20)]
         public virtual XhtmlString LongDescription { get; set; }
 
         [CultureSpecific]
         [Display(
-            Name = "Content Area",
-            Order = 4,
-            Description = "This will display the content area."
-            )]
+            Name = "Content area",
+            Description = "This will display the content area.",
+            Order = 25)]
         public virtual ContentArea ContentArea { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Show Recommendations", Order = 5, Description = "This will determine whether or not to show recommendations.")]
+        [Display(Name = "Associations title",
+            Description = "This is title of the Associations tab.",
+            Order = 30)]
+        public virtual string AssociationsTitle { get; set; }
+
+        [CultureSpecific]
+        [Display(Name = "Show recommendations", Description = "This will determine whether or not to show recommendations.", Order = 35)]
         public virtual bool ShowRecommendations { get; set; }
+
+        public override void SetDefaultValues(ContentType contentType)
+        {
+            base.SetDefaultValues(contentType);
+
+            AssociationsTitle = "You May Also Like";
+        }
     }
 }

--- a/src/Foundation.Commerce/Models/Catalog/GenericProduct.cs
+++ b/src/Foundation.Commerce/Models/Catalog/GenericProduct.cs
@@ -15,65 +15,18 @@ namespace Foundation.Commerce.Models.Catalog
     [ImageUrl("~/assets/icons/cms/pages/cms-icon-page-23.png")]
     public class GenericProduct : ProductContent, IProductRecommendations
     {
-        [Display(GroupName = SystemTabNames.Content, Order = 7)]
-        [BackingType(typeof(PropertyString))]
-        [CultureSpecific]
-        public virtual string Department { get; set; }
 
-        [Display(GroupName = SystemTabNames.Content, Order = 24)]
-        [CultureSpecific]
-        public virtual string LegalDisclaimer { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 25)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string Manufacturer { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 26)]
-        [CultureSpecific]
-        public virtual string ManufacturerPartsWarrantyDescription { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 27)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string Model { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 28)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string ModelYear { get; set; }
-
-        [Display(GroupName = SystemTabNames.Content, Order = 31)]
-        [BackingType(typeof(PropertyString))]
-        [CultureSpecific]
-        public virtual string ProductGroup { get; set; }
-
-        [Display(GroupName = SystemTabNames.Content, Order = 32)]
-        [BackingType(typeof(PropertyString))]
-        [CultureSpecific]
-        public virtual string ProductTypeName { get; set; }
-
-        [Display(GroupName = SystemTabNames.Content, Order = 33)]
-        [BackingType(typeof(PropertyString))]
-        [CultureSpecific]
-        public virtual string ProductTypeSubcategory { get; set; }
-
-        [Display(Order = 40, GroupName = CommerceTabNames.Manufacturer)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string Warranty { get; set; }
-
-        [Display(Name = "On sale", Order = 41, Description = "Is on sale?")]
-        public virtual bool OnSale { get; set; }
-
-        [Display(Name = "New arrival", Order = 42, Description = "Is on a new arrival?")]
-        public virtual bool NewArrival { get; set; }
+        #region Content
 
         [Searchable]
         [CultureSpecific]
         [Tokenize]
         [IncludeInDefaultSearch]
-        [Display(Name = "Sizing", Order = 4, GroupName = SystemTabNames.Content)]
+        [Display(Name = "Sizing", GroupName = SystemTabNames.Content, Order = 5)]
         public virtual XhtmlString Sizing { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Product Teaser", Order = 5)]
+        [Display(Name = "Product teaser", GroupName = SystemTabNames.Content, Order = 10)]
         public virtual XhtmlString ProductTeaser { get; set; }
 
         [Searchable]
@@ -81,33 +34,111 @@ namespace Foundation.Commerce.Models.Catalog
         [Tokenize]
         [IncludeInDefaultSearch]
         [BackingType(typeof(PropertyString))]
-        [Display(Name = "Brand", Order = 5)]
+        [Display(Name = "Brand", GroupName = SystemTabNames.Content, Order = 15)]
         public virtual string Brand { get; set; }
 
-        [Searchable]
         [CultureSpecific]
-        [Tokenize]
-        [IncludeInDefaultSearch]
-        [Display(Name = "Description", Order = 9)]
-        public virtual XhtmlString Description { get; set; }
+        [BackingType(typeof(PropertyString))]
+        [Display(Name = "Department", GroupName = SystemTabNames.Content, Order = 20)]
+        public virtual string Department { get; set; }
 
         [Searchable]
         [CultureSpecific]
         [Tokenize]
         [IncludeInDefaultSearch]
-        [Display(Name = "Long Description", Order = 43)]
+        [Display(Name = "Description", GroupName = SystemTabNames.Content, Order = 25)]
+        public virtual XhtmlString Description { get; set; }
+
+        [CultureSpecific]
+        [Display(Name = "Legal disclaimer", GroupName = SystemTabNames.Content, Order = 30)]
+        public virtual string LegalDisclaimer { get; set; }
+
+        [CultureSpecific]
+        [BackingType(typeof(PropertyString))]
+        [Display(Name = "Product group", GroupName = SystemTabNames.Content, Order = 35)]
+        public virtual string ProductGroup { get; set; }
+
+        [CultureSpecific]
+        [BackingType(typeof(PropertyString))]
+        [Display(Name = "Product type name", GroupName = SystemTabNames.Content, Order = 40)]
+        public virtual string ProductTypeName { get; set; }
+
+        [CultureSpecific]
+        [BackingType(typeof(PropertyString))]
+        [Display(Name = "Product type sub category", GroupName = SystemTabNames.Content, Order = 45)]
+        public virtual string ProductTypeSubcategory { get; set; }
+
+        [Display(Name = "On sale",
+            GroupName = SystemTabNames.Content,
+            Description = "Is on sale?",
+            Order = 50)]
+        public virtual bool OnSale { get; set; }
+
+        [Display(Name = "New arrival",
+            GroupName = SystemTabNames.Content,
+            Description = "Is on a new arrival?",
+            Order = 55)]
+        public virtual bool NewArrival { get; set; }
+
+        [Searchable]
+        [CultureSpecific]
+        [Tokenize]
+        [IncludeInDefaultSearch]
+        [Display(Name = "Long description", GroupName = SystemTabNames.Content, Order = 60)]
         public virtual XhtmlString LongDescription { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Content Area", Order = 44, Description = "This will display the content area.")]
+        [Display(Name = "Content area",
+            GroupName = SystemTabNames.Content,
+            Description = "This will display the content area.",
+            Order = 65)]
         public virtual ContentArea ContentArea { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Show Recommendations", Order = 50, Description = "This will determine whether or not to show recommendations.")]
+        [Display(Name = "Associations title",
+            GroupName = SystemTabNames.Content,
+            Description = "This is title of the Associations tab.",
+            Order = 70)]
+        public virtual string AssociationsTitle { get; set; }
+
+        [CultureSpecific]
+        [Display(Name = "Show recommendations",
+            GroupName = SystemTabNames.Content,
+            Description = "This will determine whether or not to show recommendations.",
+            Order = 75)]
         public virtual bool ShowRecommendations { get; set; }
 
+        #endregion
 
+        #region Manufacturer
 
+        [BackingType(typeof(PropertyString))]
+        [Display(Name = "Manufacturer", GroupName = CommerceTabNames.Manufacturer, Order = 5)]
+        public virtual string Manufacturer { get; set; }
 
+        [CultureSpecific]
+        [Display(Name = "Manufacturer parts warranty description", GroupName = CommerceTabNames.Manufacturer, Order = 10)]
+        public virtual string ManufacturerPartsWarrantyDescription { get; set; }
+
+        [BackingType(typeof(PropertyString))]
+        [Display(Name = "Model", GroupName = CommerceTabNames.Manufacturer, Order = 15)]
+        public virtual string Model { get; set; }
+
+        [Display(Name = "Model year", GroupName = CommerceTabNames.Manufacturer, Order = 20)]
+        [BackingType(typeof(PropertyString))]
+        public virtual string ModelYear { get; set; }
+
+        [BackingType(typeof(PropertyString))]
+        [Display(Name = "Warranty", GroupName = CommerceTabNames.Manufacturer, Order = 25)]
+        public virtual string Warranty { get; set; }
+
+        #endregion
+
+        public override void SetDefaultValues(ContentType contentType)
+        {
+            base.SetDefaultValues(contentType);
+
+            AssociationsTitle = "You May Also Like";
+        }
     }
 }

--- a/src/Foundation.Commerce/Models/Catalog/GenericVariant.cs
+++ b/src/Foundation.Commerce/Models/Catalog/GenericVariant.cs
@@ -14,39 +14,11 @@ namespace Foundation.Commerce.Models.Catalog
     public class GenericVariant : VariationContent, IProductRecommendations
     {
 
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 20)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string Mpn { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 21)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string PackageQuantity { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 22)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string PartNumber { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 24)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string RegionCode { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 26)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string Sku { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 27)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string SubscriptionLength { get; set; }
-
-        [Display(GroupName = CommerceTabNames.Manufacturer, Order = 29)]
-        [BackingType(typeof(PropertyString))]
-        public virtual string Upc { get; set; }
-
         [Searchable]
         [Tokenize]
         [IncludeInDefaultSearch]
         [BackingType(typeof(PropertyString))]
-        [Display(Name = "Size", Order = 4)]
+        [Display(Name = "Size", Order = 5)]
         public virtual string Size { get; set; }
 
         [Searchable]
@@ -54,39 +26,77 @@ namespace Foundation.Commerce.Models.Catalog
         [Tokenize]
         [IncludeInDefaultSearch]
         [BackingType(typeof(PropertyString))]
-        [Display(Name = "Color", Order = 5)]
+        [Display(Name = "Color", Order = 10)]
         public virtual string Color { get; set; }
 
         [Searchable]
         [CultureSpecific]
         [Tokenize]
         [IncludeInDefaultSearch]
-        [Display(Name = "Description", Order = 9)]
+        [Display(Name = "Description", Order = 15)]
         public virtual XhtmlString Description { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Content Area", Order = 44, Description = "This will display the content area.")]
+        [Display(Name = "Content area", Description = "This will display the content area.", Order = 20)]
         public virtual ContentArea ContentArea { get; set; }
 
         [CultureSpecific]
-        [Display(Name = "Show Recommendations", Order = 50, Description = "This will determine whether or not to show recommendations.")]
+        [Display(Name = "Associations title", Description = "This is title of the Associations tab.", Order = 25)]
+        public virtual string AssociationsTitle { get; set; }
+
+        [CultureSpecific]
+        [Display(Name = "Show recommendations", Description = "This will determine whether or not to show recommendations.", Order = 30)]
         public virtual bool ShowRecommendations { get; set; }
 
         [Required]
-        [Display(Name = "Virtual  Product Mode", Order = 1)]
+        [Display(Name = "Virtual product mode", Order = 35)]
         [SelectOne(SelectionFactoryType = typeof(VirtualVariantTypeSelectionFactory))]
         public virtual string VirtualProductMode { get; set; }
 
-        [Display(Name = "Virtual Product Role", Order = 1)]
+        [Display(Name = "Virtual product role", Order = 40)]
         [SelectOne(SelectionFactoryType = typeof(ElevatedRoleSelectionFactory))]
         [BackingType(typeof(PropertyString))]
         public virtual string VirtualProductRole { get; set; }
 
+        #region Manufacturer
+
+        [Display(Name = "Mpn", GroupName = CommerceTabNames.Manufacturer, Order = 5)]
+        [BackingType(typeof(PropertyString))]
+        public virtual string Mpn { get; set; }
+
+        [Display(Name = "Package quantity", GroupName = CommerceTabNames.Manufacturer, Order = 10)]
+        [BackingType(typeof(PropertyString))]
+        public virtual string PackageQuantity { get; set; }
+
+        [Display(Name = "Part number", GroupName = CommerceTabNames.Manufacturer, Order = 15)]
+        [BackingType(typeof(PropertyString))]
+        public virtual string PartNumber { get; set; }
+
+        [Display(Name = "Region code", GroupName = CommerceTabNames.Manufacturer, Order = 20)]
+        [BackingType(typeof(PropertyString))]
+        public virtual string RegionCode { get; set; }
+
+        [Display(Name = "Sku", GroupName = CommerceTabNames.Manufacturer, Order = 25)]
+        [BackingType(typeof(PropertyString))]
+        public virtual string Sku { get; set; }
+
+        [Display(Name = "Subscription length", GroupName = CommerceTabNames.Manufacturer, Order = 30)]
+        [BackingType(typeof(PropertyString))]
+        public virtual string SubscriptionLength { get; set; }
+
+        [Display(Name = "Upc", GroupName = CommerceTabNames.Manufacturer, Order = 35)]
+        [BackingType(typeof(PropertyString))]
+        public virtual string Upc { get; set; }
+
+        #endregion
+
         public override void SetDefaultValues(ContentType contentType)
         {
             base.SetDefaultValues(contentType);
+
             VirtualProductMode = "None";
             VirtualProductRole = "None";
+            AssociationsTitle = "You May Also Like";
         }
 
     }

--- a/src/Foundation/Assets/scss/templates/pages/_product-detail.scss
+++ b/src/Foundation/Assets/scss/templates/pages/_product-detail.scss
@@ -50,6 +50,10 @@
         margin-top: 20px;
         margin-bottom: 20px;
     }
+
+    &__contentarea {
+        margin-top: 20px;
+    }
 }
 
 .social-icon {
@@ -155,6 +159,10 @@
         &__right {
             margin-right: 30px;
         }
+    }
+
+    &__association {
+        padding: 15px 0px;
     }
 }
 

--- a/src/Foundation/Features/CatalogContent/Bundle/Index.cshtml
+++ b/src/Foundation/Features/CatalogContent/Bundle/Index.cshtml
@@ -2,38 +2,64 @@
 
 @model Foundation.Demo.ViewModels.DemoGenericBundleViewModel
 
-@{
-    var activeReviewTab = Request.QueryString["leavecomment"] != null;
-}
-
 <div class="row product-detail">
     @Html.Partial("_BundleDetail", Model)
 </div>
 
+@if ((Model.CurrentContent.ContentArea != null && !Model.CurrentContent.ContentArea.IsEmpty) || PageEditing.PageIsInEditMode)
+{
+    <div class="row product-detail__contentarea">
+        <div class="col-12">
+            @Html.PropertyFor(x => x.CurrentContent.ContentArea)
+        </div>
+    </div>
+}
 
 <div class="row">
     <div class="col-12">
         <ul class="nav nav-tabs product-tab" id="loginUsersTab" role="tablist">
             <li class="nav-item">
-                <a class="nav-link product-tab__item @(!activeReviewTab ? "active" : "")" data-toggle="tab" href="#product_tabs_description">
+                <a class="nav-link product-tab__item active" data-toggle="tab" href="#product_tabs_description">
                     @Html.TranslateFallback("/Shared/ProductDescription", "Product Description")
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link product-tab__item @(activeReviewTab ? "active" : "")" data-toggle="tab" href="#product_tabs_reviews">
+                <a class="nav-link product-tab__item" data-toggle="tab" href="#product_tabs_reviews">
                     @Html.TranslateFallback("/Shared/Reviews", "Reviews")
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link product-tab__item" data-toggle="tab" href="#product_tabs_associations">
+                    @if (!Model.CurrentContent.AssociationsTitle.IsNullOrEmpty() || PageEditing.PageIsInEditMode)
+                    {
+                        @Html.PropertyFor(x => x.CurrentContent.AssociationsTitle)
+                    }
+                    else
+                    {
+                        @Html.TranslateFallback("/Shared/StaticAssociations", "You May Also Like")
+                    }
                 </a>
             </li>
         </ul>
 
         <div class="tab-content">
-            <div class="tab-pane product-tab__content @(!activeReviewTab ? "fade in active show" : "fade")" id="product_tabs_description">
+            <div class="tab-pane product-tab__content fade in active show" id="product_tabs_description">
                 @Html.PropertyFor(x => x.CurrentContent.LongDescription)
             </div>
-            <div class="tab-pane product-tab__content @(activeReviewTab ? "fade in active show" : "fade")" id="product_tabs_reviews">
+            <div class="tab-pane product-tab__content fade" id="product_tabs_reviews">
                 @Html.Partial("_ReviewForm", new ReviewSubmissionViewModel(Model.Bundle.Code))
                 <div>
                     @Html.Partial("_Reviews", Model.Reviews)
+                </div>
+            </div>
+            <div class="tab-pane product-tab__content product-tab__association fade" id="product_tabs_associations">
+                <div class="row">
+                    @foreach (var association in Model.StaticAssociations.Take(4))
+                    {
+                        <div class="col-3">
+                            @Html.Partial("_Product", association)
+                        </div>
+                    }
                 </div>
             </div>
         </div>

--- a/src/Foundation/Features/CatalogContent/Package/Index.cshtml
+++ b/src/Foundation/Features/CatalogContent/Package/Index.cshtml
@@ -2,37 +2,64 @@
 
 @model Foundation.Demo.ViewModels.DemoGenericPackageViewModel
 
-@{
-    var activeReviewTab = Request.QueryString["leavecomment"] != null;
-}
-
 <div class="row product-detail">
     @Html.Partial("_PackageDetail", Model)
 </div>
+
+@if ((Model.CurrentContent.ContentArea != null && !Model.CurrentContent.ContentArea.IsEmpty) || PageEditing.PageIsInEditMode)
+{
+    <div class="row product-detail__contentarea">
+        <div class="col-12">
+            @Html.PropertyFor(x => x.CurrentContent.ContentArea)
+        </div>
+    </div>
+}
 
 <div class="row product-tabs">
     <div class="col-12">
         <ul class="nav nav-tabs product-tab" id="loginUsersTab" role="tablist">
             <li class="nav-item">
-                <a class="nav-link product-tab__item @(!activeReviewTab ? "active" : "")" data-toggle="tab" href="#product_tabs_description">
+                <a class="nav-link product-tab__item active" data-toggle="tab" href="#product_tabs_description">
                     @Html.TranslateFallback("/Shared/ProductDescription", "Product Description")
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link product-tab__item @(activeReviewTab ? "active" : "")" data-toggle="tab" href="#product_tabs_reviews">
+                <a class="nav-link product-tab__item" data-toggle="tab" href="#product_tabs_reviews">
                     @Html.TranslateFallback("/Shared/Reviews", "Reviews")
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link product-tab__item" data-toggle="tab" href="#product_tabs_associations">
+                    @if (!Model.CurrentContent.AssociationsTitle.IsNullOrEmpty() || PageEditing.PageIsInEditMode)
+                    {
+                        @Html.PropertyFor(x => x.CurrentContent.AssociationsTitle)
+                    }
+                    else
+                    {
+                        @Html.TranslateFallback("/Shared/StaticAssociations", "You May Also Like")
+                    }
                 </a>
             </li>
         </ul>
 
         <div class="tab-content">
-            <div class="tab-pane product-tab__content @(!activeReviewTab ? "fade in active show" : "fade")" id="product_tabs_description">
+            <div class="tab-pane product-tab__content fade in active show" id="product_tabs_description">
                 @Html.PropertyFor(x => x.CurrentContent.LongDescription)
             </div>
-            <div class="tab-pane product-tab__content @(activeReviewTab ? "fade in active show" : "fade")" id="product_tabs_reviews">
+            <div class="tab-pane product-tab__content fade" id="product_tabs_reviews">
                 @Html.Partial("_ReviewForm", new ReviewSubmissionViewModel(Model.Package.Code))
                 <div>
                     @Html.Partial("_Reviews", Model.Reviews)
+                </div>
+            </div>
+            <div class="tab-pane product-tab__content product-tab__association fade" id="product_tabs_associations">
+                <div class="row">
+                    @foreach (var association in Model.StaticAssociations.Take(4))
+                    {
+                        <div class="col-3">
+                            @Html.Partial("_Product", association)
+                        </div>
+                    }
                 </div>
             </div>
         </div>

--- a/src/Foundation/Features/CatalogContent/Product/Index.cshtml
+++ b/src/Foundation/Features/CatalogContent/Product/Index.cshtml
@@ -3,37 +3,65 @@
 @using Foundation.Social.ViewModels
 
 @model Foundation.Demo.ViewModels.DemoGenericProductViewModel
-@{
-    var activeReviewTab = Request.QueryString["leavecomment"] != null;
-}
 
 <div class="row product-detail">
     @Html.Partial("_ProductDetail", Model)
 </div>
 
+@if ((Model.CurrentContent.ContentArea != null && !Model.CurrentContent.ContentArea.IsEmpty) || PageEditing.PageIsInEditMode)
+{
+    <div class="row product-detail__contentarea">
+        <div class="col-12">
+            @Html.PropertyFor(x => x.CurrentContent.ContentArea)
+        </div>
+    </div>
+}
+
 <div class="row product-tabs">
     <div class="col-12">
         <ul class="nav nav-tabs product-tab" id="loginUsersTab" role="tablist">
             <li class="nav-item">
-                <a class="nav-link product-tab__item @(!activeReviewTab ? "active" : "")" data-toggle="tab" href="#product_tabs_description">
+                <a class="nav-link product-tab__item active" data-toggle="tab" href="#product_tabs_description">
                     @Html.TranslateFallback("/Shared/ProductDescription", "Product Description")
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link product-tab__item @(activeReviewTab ? "active" : "")" data-toggle="tab" href="#product_tabs_reviews">
+                <a class="nav-link product-tab__item" data-toggle="tab" href="#product_tabs_reviews">
                     @Html.TranslateFallback("/Shared/Reviews", "Reviews")
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link product-tab__item" data-toggle="tab" href="#product_tabs_associations">
+                    @if (!Model.CurrentContent.AssociationsTitle.IsNullOrEmpty() || PageEditing.PageIsInEditMode)
+                    {
+                        @Html.PropertyFor(x => x.CurrentContent.AssociationsTitle)
+                    }
+                    else
+                    {
+                        @Html.TranslateFallback("/Shared/StaticAssociations", "You May Also Like")
+                    }
                 </a>
             </li>
         </ul>
 
         <div class="tab-content">
-            <div class="tab-pane product-tab__content @(!activeReviewTab ? "fade in active show" : "fade")" id="product_tabs_description">
+            <div class="tab-pane product-tab__content fade in active show" id="product_tabs_description">
                 @Html.PropertyFor(x => x.CurrentContent.LongDescription)
             </div>
-            <div class="tab-pane product-tab__content @(activeReviewTab ? "fade in active show" : "fade")" id="product_tabs_reviews">
+            <div class="tab-pane product-tab__content fade" id="product_tabs_reviews">
                 @Html.Partial("_ReviewForm", new ReviewSubmissionViewModel(Model.Product.Code))
                 <div>
                     @Html.Partial("_Reviews", Model.Reviews)
+                </div>
+            </div>
+            <div class="tab-pane product-tab__content product-tab__association fade" id="product_tabs_associations">
+                <div class="row">
+                    @foreach (var association in Model.StaticAssociations.Take(4))
+                    {
+                        <div class="col-3">
+                            @Html.Partial("_Product", association)
+                        </div>
+                    }
                 </div>
             </div>
         </div>

--- a/src/Foundation/Features/CatalogContent/Variation/Index.cshtml
+++ b/src/Foundation/Features/CatalogContent/Variation/Index.cshtml
@@ -2,38 +2,65 @@
 
 @model Foundation.Commerce.Catalog.ViewModels.GenericVariantViewModel
 
-@{
-    var activeReviewTab = Request.QueryString["leavecomment"] != null;
-}
-
 <div class="row product-detail">
     @Html.Partial("_VariantDetail", Model)
 </div>
+
+@if ((Model.CurrentContent.ContentArea != null && !Model.CurrentContent.ContentArea.IsEmpty) || PageEditing.PageIsInEditMode)
+{
+    <div class="row product-detail__contentarea">
+        <div class="col-12">
+            @Html.PropertyFor(x => x.CurrentContent.ContentArea)
+        </div>
+    </div>
+}
 
 <div class="row product-tabs">
     <div class="col-12">
         <ul class="nav nav-tabs product-tab" id="loginUsersTab" role="tablist">
             <li class="nav-item">
-                <a class="nav-link product-tab__item @(!activeReviewTab ? "active" : "")" data-toggle="tab" href="#product_tabs_description">
+                <a class="nav-link product-tab__item active" data-toggle="tab" href="#product_tabs_description">
                     @Html.TranslateFallback("/Shared/ProductDescription", "Product Description")
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link product-tab__item @(activeReviewTab ? "active" : "")" data-toggle="tab" href="#product_tabs_reviews">
+                <a class="nav-link product-tab__item" data-toggle="tab" href="#product_tabs_reviews">
                     @Html.TranslateFallback("/Shared/Reviews", "Reviews")
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link product-tab__item" data-toggle="tab" href="#product_tabs_associations">
+                    @if (!Model.CurrentContent.AssociationsTitle.IsNullOrEmpty() || PageEditing.PageIsInEditMode)
+                    {
+                        @Html.PropertyFor(x => x.CurrentContent.AssociationsTitle)
+                    }
+                    else
+                    {
+                        @Html.TranslateFallback("/Shared/StaticAssociations", "You May Also Like")
+                    }
                 </a>
             </li>
         </ul>
 
         <div class="tab-content">
-            <div class="tab-pane product-tab__content @(!activeReviewTab ? "fade in active show" : "fade")" id="product_tabs_description">
+            <div class="tab-pane product-tab__content fade in active show" id="product_tabs_description">
                 @Html.PropertyFor(x => x.CurrentContent.Description)
             </div>
-            <div class="tab-pane product-tab__content @(activeReviewTab ? "fade in active show" : "fade")" id="product_tabs_reviews">
+            <div class="tab-pane product-tab__content fade" id="product_tabs_reviews">
                 @Html.Partial("_ReviewForm", new ReviewSubmissionViewModel(Model.CurrentContent.Code))
-                @*<div id="reviewsListing">
-                      @Html.Partial("Reviews", Model.Reviews)
+                @*<div>
+                        @Html.Partial("_Reviews", Model.Reviews)
                     </div>*@
+            </div>
+            <div class="tab-pane product-tab__content product-tab__association fade" id="product_tabs_associations">
+                <div class="row">
+                    @foreach (var association in Model.StaticAssociations.Take(4))
+                    {
+                        <div class="col-3">
+                            @Html.Partial("_Product", association)
+                        </div>
+                    }
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Make the name of the associations tab a configurable property of the product
Add ContentArea to product detail page, above Product Description and Reviews