### PR TITLE
Get current directory of batch file

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,5 @@
 @echo off
+cd /d %~dp0
 openfiles > NUL 2>&1
 if %ERRORLEVEL% NEQ 0 (
 	set "errorMessage=Build.cmd script must be run in an elevated (admin) command prompt"


### PR DESCRIPTION
When running in administrator mode, the ROOTPATH (%cd%) is C:\WINDOWS\system32, but in normal mode, the batch file gets its correct folder path (location of batch file), this line will make sure the batch file always gets its correct folder path.
cd - Change directory command.
/d - Change both drive and directory at once.
%0 - Represent zeroth parameter of the batch script. It expands into the name of the batch file itself.
%~0 - The ~ removes double quotes (") around the expanded argument.
%dp0 - The d and p are modifiers of the expansion. The d forces addition of a drive letter and the p adds full path.