### PR TITLE
use default address when checkout

### DIFF
--- a/src/Foundation/Features/Checkout/BillingInformation.cshtml
+++ b/src/Foundation/Features/Checkout/BillingInformation.cshtml
@@ -53,7 +53,11 @@
                                             values.Add(new KeyValuePair<string, string>(a.Name, a.AddressId));
                                         }
                                     }
-                                    @Helpers.RenderDropdown(values, Model.BillingAddress.AddressId, "", "BillingAddress.AddressId")
+                                    @{
+                                        var defaultBillingAddress = Model.AvailableAddresses.FirstOrDefault(x => x.BillingDefault);
+                                        var defaultBillingAddressId = defaultBillingAddress != null ? defaultBillingAddress.AddressId : null;
+                                    }
+                                    @Helpers.RenderDropdown(values, Model.BillingAddress.AddressId ?? defaultBillingAddressId, "", "BillingAddress.AddressId")
                                 </div>
                             </li>
 

--- a/src/Foundation/Features/Checkout/SingleAddress.cshtml
+++ b/src/Foundation/Features/Checkout/SingleAddress.cshtml
@@ -11,8 +11,8 @@
                     <div class="col-12">
                         @if (Model.CurrentContent.MultiShipmentPage != null)
                             {
-                                <a class="button-transparent-black pull-right" 
-                                   href="@Url.Action("MutipleAddresses", new { node = Model.CurrentContent.ContentLink })" 
+                                <a class="button-transparent-black pull-right"
+                                   href="@Url.Action("MutipleAddresses", new { node = Model.CurrentContent.ContentLink })"
                                    title="@Html.TranslateFallback("/Checkout/MultiShipment/Heading", "SHIP TO MULTIPLE ADDRESSES")">
                                     <span>
                                         @Html.TranslateFallback("/Checkout/MultiShipment/Heading", "SHIP TO MULTIPLE ADDRESSES")
@@ -61,7 +61,11 @@
                                             values.Add(new KeyValuePair<string, string>(a.Name, a.AddressId));
                                         }
                                     }
-                                    @Helpers.RenderDropdown(values, Model.Shipments[0].Address.AddressId, "", "Shipments[0].Address.AddressId")
+                                    @{
+                                        var defaultShippingAddress = Model.AvailableAddresses.FirstOrDefault(x => x.ShippingDefault);
+                                        var defaultShippingAddressId = defaultShippingAddress != null ? defaultShippingAddress.AddressId : null;
+                                    }
+                                    @Helpers.RenderDropdown(values, Model.Shipments[0].Address.AddressId ?? defaultShippingAddressId, "", "Shipments[0].Address.AddressId")
 
                                     @*@Html.DropDownListFor(model => model.Shipments[0].Address.AddressId,
                         new SelectList(Model.AvailableAddresses, "AddressId", "Name", !string.IsNullOrEmpty(Model.Shipments[0].Address.AddressId) ? Model.Shipments[0].Address.AddressId : string.Empty),


### PR DESCRIPTION
Should use default billing/shipping address as default in checkout page.
Precondition: An existing customer has address that is set as default billing/shipping
1. Add item to cart
2. Go to checkout page
-> Expected: Default billing and default shipping should be selected at checkout page
-> Actual: User need select billing and shipping address even though customer has default billing/shipping address