### PR TITLE
fix load credit card incorrectly at checkout page

### DIFF
--- a/src/Foundation.Commerce/Initialize.cs
+++ b/src/Foundation.Commerce/Initialize.cs
@@ -61,7 +61,7 @@ namespace Foundation.Commerce
             services.AddSingleton<IOrdersService, OrdersService>();
             services.AddSingleton<ShipmentViewModelFactory>();
             services.AddSingleton<IShippingService, ShippingService>();
-            services.AddSingleton<CheckoutViewModelFactory>();
+            services.AddTransient<CheckoutViewModelFactory>();
             services.AddSingleton<MultiShipmentViewModelFactory>();
             services.AddSingleton<OrderSummaryViewModelFactory>();
             services.AddTransient<PaymentMethodViewModelFactory>();


### PR DESCRIPTION
Load credit card incorrectly at checkout page
1. Register new user
2. Add some credit card for that user at customer account at demo site
3. Logout 
4. Login to another account (you can use demo user account) that does not have any credit card.
5. Checkout some item 
6. At billing step, select credit card payment
7. Click to select existing account
-> Expected: Load existing credit card of logged in user
-> Actual: Load credit card of registered user at step 1, 2