### PR TITLE
update batch script

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -277,10 +277,15 @@ echo ## Adding site to app pool ## >> Build\Logs\IIS.log
 
 echo ## Updating host file ##
 find /C /I "%APPNAME%" %WINDIR%\system32\drivers\etc\hosts
-if %ERRORLEVEL% NEQ 0 echo 127.0.0.1 %APPNAME% >> %WINDIR%\System32\drivers\etc\hosts
+if %ERRORLEVEL% NEQ 0 (
+	echo: >> %WINDIR%\System32\drivers\etc\hosts
+	echo 127.0.0.1 %APPNAME% >> %WINDIR%\System32\drivers\etc\hosts
+)
 
 find /C /I "%APPNAME%-cm" %WINDIR%\system32\drivers\etc\hosts
-if %ERRORLEVEL% NEQ 0 echo 127.0.0.1 %APPNAME%-cm >> %WINDIR%\System32\drivers\etc\hosts
+if %ERRORLEVEL% NEQ 0 (
+	echo|set /p=127.0.0.1 %APPNAME%-cm >> %WINDIR%\System32\drivers\etc\hosts
+)
 
 echo ## Copying licence file ##
 echo ## Copying licence file ## >> Build\Logs\IIS.log


### PR DESCRIPTION
If you have already data in host file, and no new line after last post. The installation/build setup is appending "127.0.0.1 aa.bbb" to content without new line before. To fix it, I add a newline before the first hostname is added. And no need to add a line break after the second hostname. (echo adds line break by default, so I disabled it)