### PR TITLE
fix shopping tag crash

### DIFF
--- a/src/Foundation/Assets/scss/templates/pages/_location.scss
+++ b/src/Foundation/Assets/scss/templates/pages/_location.scss
@@ -10,7 +10,7 @@
 
 .location__title {
     font-weight: 400;
-    font-size: 16px;
+    font-size: 20px;
 }
 
 .location__img {
@@ -22,6 +22,10 @@
 .location__description {
     font-size: 13px;
     margin: 0;
+
+    @include media-breakpoint-down(md) {
+        padding-top: 10px;
+    }
 }
 
 .location__footer {

--- a/src/Foundation/Features/Locations/TagPage/Index.cshtml
+++ b/src/Foundation/Features/Locations/TagPage/Index.cshtml
@@ -62,13 +62,13 @@
                                     </div>
                                     <div class="location__footer">
                                         <div class="row">
-                                            <div class="col-lg-10 col-md-9 col-xs-8">
+                                            <div class="col-8">
                                                 <i class="fa fa-globe"></i> @location.Continent / @location.Country
                                             </div>
-                                            <div class="col-lg-2 col-md-3 col-xs-4">
+                                            <div class="col-4">
                                                 <a href="@Url.ContentUrl(location.ContentLink)" class="pull-right">@Html.TranslateFallback("/common/readmore", "Read more »")</a>
                                             </div>
-                                            <div class="col-xs-12">
+                                            <div class="col-12">
                                                 @if (location.Tags != null)
                                                 {
                                                     <i class="fa fa-tags"></i>

--- a/src/Foundation/Features/Locations/TagPage/TagPageController.cs
+++ b/src/Foundation/Features/Locations/TagPage/TagPageController.cs
@@ -60,13 +60,16 @@ namespace Foundation.Features.Locations.TagPage
             };
             foreach (var location in model.Locations)
             {
-                carousel.Items.Add(new TagsCarouselItem
+                if (location.Image != null)
                 {
-                    Image = location.Image,
-                    Heading = location.Name,
-                    Description = location.MainIntro,
-                    ItemURL = location.ContentLink
-                });
+                    carousel.Items.Add(new TagsCarouselItem
+                    {
+                        Image = location.Image,
+                        Heading = location.Name,
+                        Description = location.MainIntro,
+                        ItemURL = location.ContentLink
+                    });
+                }
             }
             if (carousel.Items.All(item => item.Image == null) || currentPage.Images != null)
             {


### PR DESCRIPTION
check null image, if a location has an image, this location will have its carousel item to display in the tag page's carousel, otherwise, it won't, and update tag page UI a little bit