### PR TITLE
fix image URL in edit mode

### DIFF
--- a/src/Foundation.Commerce/Extensions/AssetContainerExtensions.cs
+++ b/src/Foundation.Commerce/Extensions/AssetContainerExtensions.cs
@@ -3,6 +3,7 @@ using EPiServer.Commerce.Catalog;
 using EPiServer.Commerce.Catalog.ContentTypes;
 using EPiServer.Core;
 using EPiServer.ServiceLocation;
+using EPiServer.Web;
 using EPiServer.Web.Routing;
 using System;
 using System.Collections.Generic;
@@ -35,7 +36,7 @@ namespace Foundation.Commerce.Extensions
             {
                 assets.AddRange(assetContainer.CommerceMediaCollection
                     .Where(x => ValidateCorrectType<TContentMedia>(x.AssetLink, contentLoader))
-                    .Select(media => urlResolver.GetUrl(media.AssetLink)));
+                    .Select(media => urlResolver.GetUrl(media.AssetLink, null, new VirtualPathArguments() { ContextMode = ContextMode.Default })));
             }
 
             if (!assets.Any())

--- a/src/Foundation/Helpers/HtmlHelpers.cs
+++ b/src/Foundation/Helpers/HtmlHelpers.cs
@@ -10,6 +10,7 @@ using EPiServer.Web.Routing;
 using Foundation.Cms.Pages;
 using Foundation.Cms.ViewModels;
 using Foundation.Commerce.Catalog.ViewModels;
+using Foundation.Commerce.Extensions;
 using Foundation.Demo.Models;
 using Foundation.Find.Cms.Models.Pages;
 using Foundation.Infrastructure.OpenGraph;
@@ -25,7 +26,7 @@ namespace Foundation.Helpers
     public static class HtmlHelpers
     {
         private static readonly Lazy<IContentLoader> _contentLoader = new Lazy<IContentLoader>(() => ServiceLocator.Current.GetInstance<IContentLoader>());
-        private static readonly Lazy<AssetUrlResolver> _assetUrlResolver = new Lazy<AssetUrlResolver>(() => ServiceLocator.Current.GetInstance<AssetUrlResolver>());
+        private static readonly Lazy<UrlResolver> _urlResolver = new Lazy<UrlResolver>(() => ServiceLocator.Current.GetInstance<UrlResolver>());
         private static readonly Lazy<IContentTypeRepository> _contentTypeRepository = new Lazy<IContentTypeRepository>(() => ServiceLocator.Current.GetInstance<IContentTypeRepository>());
 
         public static IHtmlString RenderOpenGraphMetaData(this HtmlHelper helper, IContentViewModel<IContent> contentViewModel)
@@ -177,7 +178,7 @@ namespace Foundation.Helpers
                     return helper.OpenGraph(openGraphCategory);
 
                 case EntryContentBase entryContentBase:
-                    var openGraphEntry = new OpenGraphGenericProduct(entryContentBase.DisplayName, new OpenGraphImage(_assetUrlResolver.Value.GetAssetUrl(entryContentBase)), GetUrl(entryContentBase.ContentLink))
+                    var openGraphEntry = new OpenGraphGenericProduct(entryContentBase.DisplayName, new OpenGraphImage(entryContentBase.GetAssets<IContentImage>(_contentLoader.Value, _urlResolver.Value).FirstOrDefault()), GetUrl(entryContentBase.ContentLink))
                     {
                         Locale = defaultLocale.Replace('-', '_'),
                         AlternateLocales = alternateLocales,


### PR DESCRIPTION
GetAssets return the URL string with the edit mode suffix. For example: http://foundation/episerver/CMS/Content/globalassets/en/catalogs/mosey/mens/shoes/jodhpur-boot/26000-8342-s19-1-f-0-0.jpg,,363?epieditmode=False
The suffix (,,363?epieditmode=False) is not necessary and should be removed