### PR TITLE
fix oversize site logo

### DIFF
--- a/src/Foundation/Assets/scss/components/_navigation.scss
+++ b/src/Foundation/Assets/scss/components/_navigation.scss
@@ -24,7 +24,7 @@
         width: 20%;
         height: $navigation-height;
 
-        > img {
+        img {
             max-height: $navigation-height - 10px;
         }
     }

--- a/src/Foundation/Features/Shared/Foundation/Header/_MobileNavigation.cshtml
+++ b/src/Foundation/Features/Shared/Foundation/Header/_MobileNavigation.cshtml
@@ -17,7 +17,7 @@
                         </div>
                     </div>
 
-                    <div class="mobile-navigation__item">
+                    <div class="mobile-navigation__item" style="@(Model.DemoHomePage.HeaderMenuStyle == "LeftLogo" ? "order: -1" : "")">
                         <a href="/" class="mobile-navigation__logo">
                             @Html.PropertyFor(model => model.DemoHomePage.SiteLogo, new { @Class = "img-fluid" })
                         </a>
@@ -42,7 +42,6 @@
                         </div>
                     </div>
                 </div>
-
 
                 <!-- Right Menu -->
                 <div class="mobile-navigation__right">

--- a/src/Foundation/Features/Shared/Foundation/Header/_Navigation.cshtml
+++ b/src/Foundation/Features/Shared/Foundation/Header/_Navigation.cshtml
@@ -1,14 +1,18 @@
 ﻿@model Foundation.Demo.ViewModels.DemoHeaderViewModel
-@Html.FullRefreshPropertiesMetaData(new[] { "MainMenu" })
+@Html.FullRefreshPropertiesMetaData(new[] { "MainMenu", "SiteLogo" })
+
 <!-- Navigation bar for Desktop -->
 <div class="d-none d-lg-block">
     <nav class="container navigation">
         <div class="navigation__left" @Html.EditAttributes(x => x.HomePage.MainMenu)>
             @Html.Partial("_Menu", Model.MenuItems)
         </div>
-        <a href="/" class="navigation__logo @(Model.DemoHomePage.HeaderMenuStyle == "LeftLogo" ? "flex-start" : "flex-center")" style="@(Model.DemoHomePage.HeaderMenuStyle == "LeftLogo" ? "order: -1" : "")">
-            @Html.PropertyFor(model => model.DemoHomePage.SiteLogo, new { @class = "img-fluid" })
-        </a>
+        <div class="navigation__logo @(Model.DemoHomePage.HeaderMenuStyle == "LeftLogo" ? "flex-start" : "flex-center")"
+             style="@(Model.DemoHomePage.HeaderMenuStyle == "LeftLogo" ? "order: -1; width: auto" : "")">
+            <a href="/">
+                <img class="img-fluid" src="@Url.ContentUrl(Model.DemoHomePage.SiteLogo)" @Html.EditAttributes(x => x.DemoHomePage.SiteLogo) />
+            </a>
+        </div>
         <ul class="navigation__right">
             @if (Request.IsAuthenticated)
             {


### PR DESCRIPTION
In edit mode, if the image is very big, it will spread over the menu since the bootstrap class "img-fluid" is placed in the wrong place
```
<div class="epi-editContainer" data-epi-property-name="SiteLogo" data-epi-use-mvc="True" data-epi-property-rendersettings="{"class":"img-fluid";}">
<img src="/episerver/CMS/Content/globalassets/en/_mosey/mosey-logo.svg,,151?epieditmode=False" alt="">
</div>
```
Make the navigation a bit closer to the logo when Logo is the left position.
Update left logo for mobile view