### PR TITLE
Display information hidden by syntax error

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Acts as integration branch for feature and bugfix branches that should go into t
 
 ### Feature branches
 
-Created from develop and should be named feature/<issue id in github>-<short description>. For example to work on "User Story 35: Remove the 'Classic' link stage in the API and only use permanent links" you would create a branch from develop named "feature/35-remove-classic-links". Note that the `<short description>` is all lower-case with hyphens.
+Created from develop and should be named feature/`<issue id in github>-<short description>`. For example to work on "User Story 35: Remove the 'Classic' link stage in the API and only use permanent links" you would create a branch from develop named "feature/35-remove-classic-links". Note that the `<short description>` is all lower-case with hyphens.
 
 Merge to the develop branch by creating a pull request.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,13 +55,13 @@ Acts as integration branch for feature and bugfix branches that should go into t
 
 ### Feature branches
 
-Created from develop and should be named feature/<issue id in github>-<short description>. For example to work on "User Story 35: Remove the 'Classic' link stage in the API and only use permanent links" you would create a branch from develop named "feature/35-remove-classic-links". Note that the <short description> is all lower-case with hyphens.
+Created from develop and should be named feature/<issue id in github>-<short description>. For example to work on "User Story 35: Remove the 'Classic' link stage in the API and only use permanent links" you would create a branch from develop named "feature/35-remove-classic-links". Note that the `<short description>` is all lower-case with hyphens.
 
 Merge to the develop branch by creating a pull request.
 
 ### Bugfix branches
 
-Created from develop and should be named bugfix/<issue id in github>-<short description>. For example to work on "Bug 111571: MVC rendering of built-in properties" you should create a branch named something like "bugfix/111571-mvc-rendering-properties". Note that the <short description> is all lower-case with hyphens.
+Created from develop and should be named bugfix/`<issue id in github>-<short description>`. For example to work on "Bug 111571: MVC rendering of built-in properties" you should create a branch named something like "bugfix/111571-mvc-rendering-properties". Note that the `<short description>` is all lower-case with hyphens.
 
 Merge to the develop branch by creating a pull request.
 


### PR DESCRIPTION
Words using <> are hidden because markdown interprets them as html.
Surrounded these words with back-ticks instead for syntax highlighting.