### PR TITLE
BreadcrumbAlignmentOptionSelectionFactory class name typo

### DIFF
--- a/src/Foundation.Cms/Blocks/BreadCrumbBlock.cs
+++ b/src/Foundation.Cms/Blocks/BreadCrumbBlock.cs
@@ -22,7 +22,7 @@ namespace Foundation.Cms.Blocks
         public virtual string Separator { get; set; }
 
         [Display(Name = "Alignment option", Order = 30, GroupName = SystemTabNames.Content)]
-        [SelectOne(SelectionFactoryType = typeof(BreadcrumbAlginmentOptionSelectionFactory))]
+        [SelectOne(SelectionFactoryType = typeof(BreadcrumbAlignmentOptionSelectionFactory))]
         public virtual string Alignment { get; set; }
 
         public override void SetDefaultValues(ContentType contentType)

--- a/src/Foundation.Cms/EditorDescriptors/BreadcrumbAlignmentOptionSelectionFactory.cs
+++ b/src/Foundation.Cms/EditorDescriptors/BreadcrumbAlignmentOptionSelectionFactory.cs
@@ -9,9 +9,9 @@ namespace Foundation.Cms.EditorDescriptors
         {
             var separators = new List<SelectItem>
             {
-                new SelectItem() {Text = "Left", Value = "flex-start"},
-                new SelectItem() {Text = "Right", Value = "flex-end"},
-                new SelectItem() {Text = "Center", Value = "flex-center"},
+                new SelectItem {Text = "Left", Value = "flex-start"},
+                new SelectItem {Text = "Right", Value = "flex-end"},
+                new SelectItem {Text = "Center", Value = "flex-center"}
             };
 
             return separators;

--- a/src/Foundation.Cms/EditorDescriptors/BreadcrumbAlignmentOptionSelectionFactory.cs
+++ b/src/Foundation.Cms/EditorDescriptors/BreadcrumbAlignmentOptionSelectionFactory.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Foundation.Cms.EditorDescriptors
 {
-    public class BreadcrumbAlginmentOptionSelectionFactory : ISelectionFactory
+    public class BreadcrumbAlignmentOptionSelectionFactory : ISelectionFactory
     {
         public IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
         {

--- a/src/Foundation.Cms/EditorDescriptors/BreadcrumbSeparatorSelectionFactory.cs
+++ b/src/Foundation.Cms/EditorDescriptors/BreadcrumbSeparatorSelectionFactory.cs
@@ -9,12 +9,12 @@ namespace Foundation.Cms.EditorDescriptors
         {
             var separators = new List<SelectItem>
             {
-                new SelectItem() {Text = "> Single arrow", Value = ">"},
-                new SelectItem() {Text = "/ Forward slash", Value = "/"},
-                new SelectItem() {Text = @"\ Backward slash", Value = @"\"},
-                new SelectItem() {Text = "» Double arrow", Value = "»"},
-                new SelectItem() {Text = "| Pipe", Value = "|"},
-                new SelectItem() {Text = ": Pipe", Value = ":"}
+                new SelectItem {Text = "> Single arrow", Value = ">"},
+                new SelectItem {Text = "/ Forward slash", Value = "/"},
+                new SelectItem {Text = @"\ Backward slash", Value = @"\"},
+                new SelectItem {Text = "» Double arrow", Value = "»"},
+                new SelectItem {Text = "| Pipe", Value = "|"},
+                new SelectItem {Text = ": Pipe", Value = ":"}
             };
 
             return separators;

--- a/src/Foundation.Commerce/Models/EditorDescriptors/GenericNodeSelectionFactory.cs
+++ b/src/Foundation.Commerce/Models/EditorDescriptors/GenericNodeSelectionFactory.cs
@@ -7,10 +7,10 @@ namespace Foundation.Commerce.Models.EditorDescriptors
     {
         public IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
         {
-            return new List<ISelectItem>()
+            return new List<ISelectItem>
             {
-                new SelectItem() { Text = "List", Value = "List" },
-                new SelectItem() { Text = "Grid", Value = "Grid" }
+                new SelectItem { Text = "List", Value = "List" },
+                new SelectItem { Text = "Grid", Value = "Grid" }
             };
         }
     }


### PR DESCRIPTION
1) Fix typo in BreadcrumbAlignmentOptionSelectionFactory class name

2) Remove redundant parentheses, to match code style of in rest of repository, like TeaserBlockElementOrderSelectionFactory, HeaderMenuSelectionFactory, ProductSearchBlockItemsPerRowSelectionFactory etc.