### PR TITLE
Remove redundant override

### DIFF
--- a/src/Foundation.Cms/Pages/BlogItemPage.cs
+++ b/src/Foundation.Cms/Pages/BlogItemPage.cs
@@ -24,10 +24,5 @@ namespace Foundation.Cms.Pages
             GroupName = SystemTabNames.Content,
             Order = 210)]
         public virtual BlogCommentBlock Comments { get; set; }
-
-        public override void SetDefaultValues(ContentType contentType)
-        {
-            base.SetDefaultValues(contentType);
-        }
     }
 }


### PR DESCRIPTION
The redundant override adds no functionality, and may safely be removed.