### PR TITLE
add default display option for teaser block

### DIFF
--- a/src/Foundation.Cms/Blocks/TeaserBlock.cs
+++ b/src/Foundation.Cms/Blocks/TeaserBlock.cs
@@ -1,3 +1,4 @@
+using EPiBootstrapArea;
 using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.DataAnnotations;
@@ -12,6 +13,7 @@ namespace Foundation.Cms.Blocks
         GUID = "EB67A99A-E239-41B8-9C59-20EAA5936047",
         Description = "Image block with overlay for text",
         GroupName = CmsGroupNames.Content)]
+    [DefaultDisplayOption(ContentAreaTags.OneThirdWidth)]
     [ImageUrl("~/assets/icons/cms/blocks/CMS-icon-block-26.png")]
     public class TeaserBlock : FoundationBlockData
     {


### PR DESCRIPTION
#334
@lunchin I think we cannot set default display option for Page Partial and Form, we can only make the default for the ContentArea which they are dragged in using Tags or something else. So I only updated the Teaser Block.