### PR TITLE
Removed unused GeoLiteCity.dat reference in Foundation.csproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ Setup*.log
 # Foundation
 Build/Logs/*.log
 src/appdata/*
-src/Foundation/App_Data/GeoLiteCity.dat
 src/Foundation/Assets/scss/main.min.css
 src/Foundation/Assets/scss/main.min.css.map
 src/Foundation/Assets/js/main.min.js

--- a/src/Foundation/Foundation.csproj
+++ b/src/Foundation/Foundation.csproj
@@ -1847,7 +1847,6 @@
     <Content Include="modules\_protected\EPiServer.Commerce.Shell\EPiServer.Commerce.Shell.zip" />
     <Content Include="modules\_protected\Commerce\Commerce.zip" />
     <Content Include="modules\_protected\EPiServer.Commerce.UI.CustomerService\EPiServer.Commerce.UI.CustomerService.zip" />
-    <Content Include="App_Data\GeoLiteCity.dat" />
     <Content Include="modules\_protected\CmsAudit\Views\web.config" />
     <Content Include="modules\_protected\CmsAudit\Views\VisitorGroups\Index.cshtml" />
     <Content Include="modules\_protected\CmsAudit\Views\Shared\_layout.cshtml" />


### PR DESCRIPTION
Removed the reference in Foundation.csproj to App_Data\GeoLiteCity.dat , since it looks to be unused, and now replaced by GeoLite2-City.mmdb instead. This was causing issues when trying to build & deploy the project via CI systems, since they are looking for the referenced GeoLiteCity.dat file.