### PR TITLE
fix hero block opacity

### DIFF
--- a/src/Foundation.Cms/Blocks/FoundationBlockData.cs
+++ b/src/Foundation.Cms/Blocks/FoundationBlockData.cs
@@ -27,10 +27,6 @@ namespace Foundation.Cms.Blocks
         [Display(Name = "Background color", GroupName = CmsTabNames.BlockStyling, Order = 3)]
         public virtual string BackgroundColor { get; set; }
 
-        [Range(0, 1.0, ErrorMessage = "Opacity only allows value between 0 and 1")]
-        [Display(Name = "Block opacity (0 to 1)", GroupName = CmsTabNames.BlockStyling, Order = 4)]
-        public virtual double BlockOpacity { get; set; }
-
         public override void SetDefaultValues(ContentType contentType)
         {
             base.SetDefaultValues(contentType);
@@ -38,7 +34,6 @@ namespace Foundation.Cms.Blocks
             Padding = "p-1";
             Margin = "m-0";
             BackgroundColor = "background-color: transparent;";
-            BlockOpacity = 1;
         }
     }
 }

--- a/src/Foundation.Cms/Blocks/HeroBlock.cs
+++ b/src/Foundation.Cms/Blocks/HeroBlock.cs
@@ -29,15 +29,19 @@ namespace Foundation.Cms.Blocks
         [Display(Order = 30)]
         public virtual Url Link { get; set; }
 
+        [Range(0, 1.0, ErrorMessage = "Opacity only allows value between 0 and 1")]
+        [Display(Name = "Block opacity (0 to 1)", GroupName = CmsTabNames.BlockStyling, Order = 40)]
+        public virtual double BlockOpacity { get; set; }
+
         [UIHint("HeroBlockCallout")]
-        [Display(Name = "Callout", GroupName = SystemTabNames.Content, Order = 40)]
+        [Display(Name = "Callout", GroupName = SystemTabNames.Content, Order = 50)]
         public virtual HeroBlockCallout Callout { get; set; }
 
         public override void SetDefaultValues(ContentType contentType)
         {
             base.SetDefaultValues(contentType);
 
-            BlockOpacity = 1;
+            BlockOpacity = 0;
         }
     }
 

--- a/src/Foundation/Assets/scss/templates/blocks/_hero-block.scss
+++ b/src/Foundation/Assets/scss/templates/blocks/_hero-block.scss
@@ -27,7 +27,7 @@
         position: absolute;
         width: 100%;
         height: 100%;
-        background-color: transparent;
+        background-color: black;
     }
 
     &__callout {

--- a/src/Foundation/Features/Blocks/Views/ButtonBlock.cshtml
+++ b/src/Foundation/Features/Blocks/Views/ButtonBlock.cshtml
@@ -1,6 +1,6 @@
 @model IBlockViewModel<ButtonBlock>
 
-<div style="@Model.CurrentBlock.BackgroundColor opacity:@Model.CurrentBlock.BlockOpacity;" class="@(Model.CurrentBlock.Padding + " " + Model.CurrentBlock.Margin)">
+<div style="@Model.CurrentBlock.BackgroundColor" class="@(Model.CurrentBlock.Padding + " " + Model.CurrentBlock.Margin)">
     <a class="@Model.CurrentBlock.ButtonStyle" title="@Model.CurrentBlock.ButtonText" href="@Url.ContentUrl(Model.CurrentBlock.ButtonLink)" @Html.EditAttributes(m => m.CurrentBlock.ButtonText)>
         @{
             var buttonText = string.IsNullOrWhiteSpace(Model.CurrentBlock.ButtonText)

--- a/src/Foundation/Features/Blocks/Views/HeroBlock.cshtml
+++ b/src/Foundation/Features/Blocks/Views/HeroBlock.cshtml
@@ -3,8 +3,6 @@
 @model IBlockViewModel<HeroBlock>
 
 @{
-    
-   
     var calloutTextColor = string.Empty;
     if (Model.CurrentBlock.Callout.CalloutTextColor.Equals("Light"))
     {

--- a/src/Foundation/Features/Blocks/Views/TextBlock.cshtml
+++ b/src/Foundation/Features/Blocks/Views/TextBlock.cshtml
@@ -1,5 +1,5 @@
 ﻿@model IBlockViewModel<TextBlock>
 
-<div style="@Model.CurrentBlock.BackgroundColor opacity:@Model.CurrentBlock.BlockOpacity;" class="@(Model.CurrentBlock.Padding + " " + Model.CurrentBlock.Margin)">
+<div style="@Model.CurrentBlock.BackgroundColor" class="@(Model.CurrentBlock.Padding + " " + Model.CurrentBlock.Margin)">
     @Html.PropertyFor(x => x.CurrentBlock.MainBody, new { CssClass = "word-break" })
 </div>


### PR DESCRIPTION
@lunchin 
In a Jacob's request, he wanted to make the hero block a little bit darker in some cases, so I added a layer to have color black and opacity around 0.5. The transparent issue you fixed in [this commit](https://github.com/episerver/Foundation/commit/be955462b33ff243a8dea1c1bd6975488bc2508b) does not cause by the background color, it's about the Default BlockOpacity value you set 1 in [this commit](https://github.com/episerver/Foundation/commit/46d18959c372c5ae0a59fb5f870181cfe7d8a76c). The default should be 0 and keep the background-color black.

Soon, I found out that you are using this Opacity for Button Block, Textblock. Since this property is intended for hero block at first. Do we really need to put it in Block base class? Not really get your idea, but if you want to keep this, I can adjust Hero block a bit to fit your idea.