### PR TITLE
update mega menu experience

### DIFF
--- a/src/Foundation/Assets/scss/components/_navigation.scss
+++ b/src/Foundation/Assets/scss/components/_navigation.scss
@@ -101,6 +101,7 @@
     position: absolute;
     background-color: white;
     z-index: 9;
+    transition: 0.2s 0.2s;
 
     .mega-menu {
         &--header__item {


### PR DESCRIPTION
when hover menu item, the mega menu displays, and the mega menu does not disappear when you accidently move across other menu item but you do not intend to hover them