### PR TITLE
Fix issue around marketviewmodel caching

### DIFF
--- a/src/Foundation.Commerce/Initialize.cs
+++ b/src/Foundation.Commerce/Initialize.cs
@@ -81,20 +81,6 @@ namespace Foundation.Commerce
 
         void IInitializableModule.Initialize(InitializationEngine context)
         {
-            MarketEvent.ChangeMarket += ChangeMarket;
-        }
-
-        private void ChangeMarket(object o, EventArgs e)
-        {
-            var market = o as IMarket;
-            if (market != null)
-            {
-                var marketCache = CacheManager.Get(Constant.CacheKeys.MarketViewModel) as MarketViewModel;
-                if (marketCache.MarketId != market.MarketId)
-                {
-                    CacheManager.Remove(Constant.CacheKeys.MarketViewModel);
-                }
-            }
         }
 
         void IInitializableModule.Uninitialize(InitializationEngine context)

--- a/src/Foundation.Commerce/ViewModels/Header/CommerceHeaderViewModelFactory.cs
+++ b/src/Foundation.Commerce/ViewModels/Header/CommerceHeaderViewModelFactory.cs
@@ -247,14 +247,14 @@ namespace Foundation.Commerce.ViewModels.Header
 
         protected virtual void AddMarketViewModel(IContent currentContent, CommerceHeaderViewModel viewModel)
         {
-            var marketsViewModel = CacheManager.Get(Constant.CacheKeys.MarketViewModel) as MarketViewModel;
-            if (marketsViewModel != null)
+            var currentMarket = _currentMarket.GetCurrentMarket();
+
+            if (CacheManager.Get(Constant.CacheKeys.MarketViewModel + "-" + currentMarket.MarketId.Value) is MarketViewModel marketsViewModel)
             {
                 viewModel.Markets = marketsViewModel;
             }
             else
             {
-                var currentMarket = _currentMarket.GetCurrentMarket();
                 var markets = _marketService.GetAllMarkets().Where(x => x.IsEnabled).OrderBy(x => x.MarketName)
                     .Select(x => new MarketItem
                     {
@@ -266,19 +266,19 @@ namespace Foundation.Commerce.ViewModels.Header
                 marketsViewModel = new MarketViewModel
                 {
                     Markets = markets,
-                    MarketId = currentMarket != null ? currentMarket.MarketId.Value : string.Empty,
-                    CurrentMarket = currentMarket != null ? new MarketItem
+                    MarketId = currentMarket.MarketId.Value,
+                    CurrentMarket = new MarketItem
                     {
                         Selected = false,
                         Text = currentMarket.MarketName,
                         Value = currentMarket.MarketId.Value,
                         FlagUrl = GetFlagUrl(currentMarket.MarketId)
-                    } : null,
+                    },
                     ContentLink = currentContent?.ContentLink ?? ContentReference.EmptyReference
                 };
                 viewModel.Markets = marketsViewModel;
 
-                CacheManager.Insert(Constant.CacheKeys.MarketViewModel, marketsViewModel, new CacheEvictionPolicy(TimeSpan.FromHours(1), CacheTimeoutType.Sliding));
+                CacheManager.Insert(Constant.CacheKeys.MarketViewModel + "-" + currentMarket.MarketId.Value, marketsViewModel, new CacheEvictionPolicy(TimeSpan.FromHours(1), CacheTimeoutType.Sliding));
             }
         }
 


### PR DESCRIPTION
This code around Market handling and specifically the use of CacheManager needs to be reviewed. An example is the AddMarketViewModel method. It is executed for every visitor to the site, on every request. It uses the CacheManager which is global for the entire application. This means it is not possible to have more than one user in different markets without strange results.

To fix cache the MarketViewModel taking the user's market into account so other users in the same market can take advantage of the cached model.

To recreate:

- Open a browser and browse the site using the USA market
- Open a incognito window and browse to site, select the UK market
- Back in the non-incognito market refresh
- In the incognito window refresh
- Note that the incognito window is show UK as the market but USA as prices