### PR TITLE
Update Mediachase.Search.* version references in csproj files

### DIFF
--- a/src/Foundation.CommerceManager/Foundation.CommerceManager.csproj
+++ b/src/Foundation.CommerceManager/Foundation.CommerceManager.csproj
@@ -187,10 +187,10 @@
     <Reference Include="Mediachase.Search.Extensions, Version=13.31.1.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.Commerce.Core.13.31.1\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search.Extensions.Azure, Version=13.31.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+    <Reference Include="Mediachase.Search.Extensions.Azure, Version=13.31.1.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.CommerceManager.Azure.14.0.20\lib\net462\Mediachase.Search.Extensions.Azure.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search.LuceneAzureSearchProvider, Version=13.31.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Mediachase.Search.LuceneAzureSearchProvider, Version=13.31.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.CommerceManager.Azure.14.0.20\lib\net462\Mediachase.Search.LuceneAzureSearchProvider.dll</HintPath>
     </Reference>
     <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=13.31.1.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Foundation/Foundation.csproj
+++ b/src/Foundation/Foundation.csproj
@@ -610,10 +610,10 @@
     <Reference Include="Mediachase.Search.Extensions, Version=13.31.1.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.Commerce.Core.13.31.1\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search.Extensions.Azure, Version=13.31.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+    <Reference Include="Mediachase.Search.Extensions.Azure, Version=13.31.1.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.Commerce.Azure.14.0.20\lib\net462\Mediachase.Search.Extensions.Azure.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search.LuceneAzureSearchProvider, Version=13.31.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Mediachase.Search.LuceneAzureSearchProvider, Version=13.31.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.Commerce.Azure.14.0.20\lib\net462\Mediachase.Search.LuceneAzureSearchProvider.dll</HintPath>
     </Reference>
     <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=13.31.1.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
Update Mediachase.Search.LuceneAzureSearchProvider and Mediachase.Search.Extensions.Azure to 13.31.1.0, to correct warnings during build.