### PR TITLE
Added double quotes for the sql servername

### DIFF
--- a/setup.cmd
+++ b/setup.cmd
@@ -118,7 +118,7 @@ echo ## Dropping user ##
 echo ## Dropping user ## >> Build\Logs\Database.log
 %sql% -Q "if exists (select loginname from master.dbo.syslogins where name = '%user%') EXEC sp_droplogin @loginame='%user%'" >> Build\Logs\Database.log
 
-powershell -command "&{.\build\build.ps1 -server %SQLSERVER% -additionalSQL %ADDITIONAL_SQLCMD% -appName %APPNAME% "}" 
+powershell -command "&{.\build\build.ps1 -server ""%SQLSERVER%"" -additionalSQL %ADDITIONAL_SQLCMD% -appName %APPNAME% "}" 
 
 echo ## Installing foundation configuration ##
 echo ## Installing foundation configuration ## >> Build\Logs\Database.log


### PR DESCRIPTION
When using (localdb)\mssqllocaldb as a server the script fails because powershell parses the servername as powershell syntax - adding double  quotes seems to work 