### PR TITLE
Add property to set alt title to display on page teasers instead of page title

### DIFF
--- a/src/Foundation/Features/Shared/FoundationPageData.cs
+++ b/src/Foundation/Features/Shared/FoundationPageData.cs
@@ -111,6 +111,10 @@ namespace Foundation.Features.Shared
         [Display(Name = "Teaser ratio (width-height)", GroupName = TabNames.Teaser, Order = 50)]
         public virtual string TeaserRatio { get; set; }
 
+        [CultureSpecific]
+        [Display(Name = "Teaser title", GroupName = TabNames.Teaser, Order = 70)]
+        public virtual string TeaserTitle { get; set; }
+
         [UIHint(UIHint.Image)]
         [Display(Name = "Image", GroupName = TabNames.Teaser, Order = 100)]
         public virtual ContentReference PageImage { get; set; }

--- a/src/Foundation/Features/Shared/Views/_Page.cshtml
+++ b/src/Foundation/Features/Shared/Views/_Page.cshtml
@@ -70,7 +70,14 @@
         }
         <div class="screen-width-wrapper">
             <div class="teaser-text @textStyle screen-width-container">
-                <h2 @Html.EditAttributes(x => x.PageName)>@Model.PageName</h2>
+                @if (!String.IsNullOrWhiteSpace(Model.TeaserTitle))
+                {
+                    <h2 @Html.EditAttributes(x => x.TeaserTitle)>@Model.TeaserTitle</h2>
+                }
+                else
+                {
+                    <h2 @Html.EditAttributes(x => x.PageName)>@Model.PageName</h2>
+                }
                 <div class="teaser-text__details">
                     @if (!String.IsNullOrWhiteSpace(Model.TeaserText))
                     {


### PR DESCRIPTION
New "Teaser Title" property on "Teasers" tab for pages. When page is used as a teaser, if "Teaser Title" is defined then it is displayed on card instead of page title.