### PR TITLE
Update login URL for user login widget to use relative path

### DIFF
--- a/src/Foundation/Features/Shared/Views/Header/_Users.cshtml
+++ b/src/Foundation/Features/Shared/Views/Header/_Users.cshtml
@@ -164,7 +164,7 @@
                         @foreach (var user in Model.DemoUsers)
                         {
                             var url = Url.Action("Login", "PublicApi");
-                            <a href="@(url + "?userName=" + user.Email + "&returnUrl=" + this.Url.ActionContext.HttpContext.Request.GetDisplayUrl())" class="list-group--header__item">
+                            <a href="@(url + "?userName=" + user.Email + "&returnUrl=" + this.Url.ActionContext.HttpContext.Request.GetEncodedPathAndQuery())" class="list-group--header__item">
                                 <p>@user.FullName</p>
                                 <p class="sub-title">@user.Description</p>
                             </a>


### PR DESCRIPTION
Using a relative path means the login URL will follow the scheme (HTTP vs HTTPS) that's currently in use. GetDisplayUrl() did not respect the scenario where HTTPS was enabled at Cloudflare level.