### PR TITLE
Set Json property naming policy to leave property names unchanged

### DIFF
--- a/src/Foundation/Startup.cs
+++ b/src/Foundation/Startup.cs
@@ -151,6 +151,12 @@ namespace Foundation
                     });
                 }
             });
+            // Don't camelCase Json output -- leave property names unchanged
+            services.AddControllers()
+                .AddJsonOptions(options =>
+                {
+                    options.JsonSerializerOptions.PropertyNamingPolicy = null;
+                });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
By default, JsonResult objects were camel-casing their objects -- for example, when adding to cart:
![image](https://user-images.githubusercontent.com/12244947/151091198-4de4ffe5-9652-48ed-ab36-9a546e3e6bed.png)

As a result, product.js (and possibly other code) was failing (result.data.statusCode != result.data.StatusCode).

For reference, the same object via the older version of Foundation:
![image](https://user-images.githubusercontent.com/12244947/151091349-5f11f855-f1ec-4e66-a0b3-30c35875fff6.png)

To validate -- go to a product detail page, and click the "Add to Cart" button. A success message should show in the top-right of the screen, and the quantity shown in the cart icon should update.

Alternatively, if we don't want to make this a global change, it can be fixed by either:
1) Updating product.js (and any other code that acts on the json results) to look for camelCase property names

Or, 2) Modifying each of the JsonResult objects with an option setting. For example:



	var jsonOptions = new JsonSerializerOptions()
	{
		PropertyNamingPolicy = null
	};

	if (result.ValidationMessages.Count > 0)
	{
		return Json(new ChangeCartJsonResult
		{
			StatusCode = result.EntriesAddedToCart ? 1 : 0,
			CountItems = (int)CartWithValidationIssues.Cart.GetAllLineItems().Sum(x => x.Quantity),
			Message = product + " is added to the cart successfully.\n" + result.GetComposedValidationMessage(),
			SubTotal = CartWithValidationIssues.Cart.GetSubTotal()
		}, jsonOptions);
	}
