### PR TITLE
Update paths in bulk-update.js to match BulkUpdateController.cs

### DIFF
--- a/src/Foundation/wwwroot/js/extensions/bulk-update.js
+++ b/src/Foundation/wwwroot/js/extensions/bulk-update.js
@@ -15,7 +15,7 @@
         var inst = typeof (e) !== 'undefined' ? e.data.inst : this;
         $('.loading-box').show();
         let filter = $('.content-group-filter').val();
-        axios.get("bulkupdate/getcontenttypes/?type=" + filter)
+        axios.get("bulkupdate/getcontenttypes/" + filter)
             .then(function (result) {
                 $('.content-type-filter').empty();
                 $.each(result.data,
@@ -115,7 +115,7 @@
         var language = $('.content-language-filter').val();
         var keyword = $('.content-name-filter').val();
 
-        axios.get("bulkupdate/get?contentTypeId=" + contentTypeId + "&language=" + language + "&properties=" + properties.join() + "&keyword=" + keyword)
+        axios.get("bulkupdate/getContent?contentTypeId=" + contentTypeId + "&language=" + language + "&properties=" + properties.join() + "&keyword=" + keyword)
             .then(function (result) {
                 inst.contents = result.data;
                 if (result.data.length > 0) {


### PR DESCRIPTION
Updated the js file to match the changes in the controller -- let me know if you'd prefer to make the changes in the controller instead.

Two known issues:
1) If you don't select any other properties via the checkboxes, it will not update a page name -- it responds "The given key '' was not present in the dictionary." (Need to set a default?)

2) Some content types return an error -- for example: select Block, Hero Block, English, leave the keyword empty, and then click Apply -- 500 error is returned.