### PR TITLE
Invalidate promotion cache when creating new coupons

### DIFF
--- a/src/Foundation/Infrastructure/Commerce/Marketing/UniqueCouponService.cs
+++ b/src/Foundation/Infrastructure/Commerce/Marketing/UniqueCouponService.cs
@@ -62,6 +62,8 @@ namespace Foundation.Infrastructure.Commerce.Marketing
                 {
                     InvalidateCouponCache(coupon.Id);
                 }
+                int promoId = coupons[0].PromotionId;
+                InvalidatePromotionCache(promoId);
 
                 return true;
             }


### PR DESCRIPTION
With this change, creating new coupons will invalidate the promotion cache, so that when the editPromotionCoupons page reloads you can see the newly created coupons.

For review -- there may be performance reasons that I'm not aware of to keep as-is.