### PR TITLE
Update SettingsService to fall back to wildcard when resolving SiteDe…

### DIFF
--- a/src/Foundation/Infrastructure/Cms/Settings/SettingsService.cs
+++ b/src/Foundation/Infrastructure/Cms/Settings/SettingsService.cs
@@ -400,7 +400,7 @@ namespace Foundation.Infrastructure.Cms.Settings
             {
                 return Guid.Empty;
             }
-            var site = _siteDefinitionResolver.GetByHostname(request.Host.Host, false, out var hostname);
+            var site = _siteDefinitionResolver.GetByHostname(request.Host.Host, true, out var hostname);
             if (site == null)
             {
                 return Guid.Empty;


### PR DESCRIPTION
…finition

This should ensure layoutsettings is not null on a default Foundation site when running under a different hostname in IIS. 

Previously, layoutsettings was returning as null, causing null reference exceptions when rendering headers.