### PR TITLE
Update net5 branch readme -- deprecated branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<a href="https://github.com/episerver/Foundation"><img src="http://ux.episerver.com/images/logo.png" title="Foundation" alt="Foundation"></a>
+## NOTE: this branch is deprecated -- use the [main branch](https://github.com/episerver/Foundation/tree/main) for CMS 12 / .NET 5.
+
+---
 
 ## Foundation 
 


### PR DESCRIPTION
Updated readme to make it clearer that visitors should use the "main" branch, not the "net5" branch.