### PR TITLE
Product search enhancements - hide from search, boosting

### DIFF
--- a/src/Foundation/Features/CatalogContent/DynamicCatalogContent/DynamicVariation/DynamicVariant.cs
+++ b/src/Foundation/Features/CatalogContent/DynamicCatalogContent/DynamicVariation/DynamicVariant.cs
@@ -7,6 +7,7 @@ using EPiServer.Shell.ObjectEditing;
 using EPiServer.Validation;
 using EPiServer.Web;
 using Foundation.Features.CatalogContent.Variation;
+using Foundation.Infrastructure.Commerce.Models.EditorDescriptors;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Foundation/Features/CatalogContent/Product/GenericProduct.cs
+++ b/src/Foundation/Features/CatalogContent/Product/GenericProduct.cs
@@ -21,7 +21,6 @@ namespace Foundation.Features.CatalogContent.Product
     public class GenericProduct : ProductContent, IProductRecommendations, IFoundationContent/*, IDashboardItem*/
     {
         #region Content
-
         [Searchable]
         [CultureSpecific]
         [Tokenize]
@@ -114,7 +113,17 @@ namespace Foundation.Features.CatalogContent.Product
             Order = 80)]
         [SelectOne(SelectionFactoryType = typeof(ProductStatusSelectionFactory))]
         public virtual string ProductStatus { get; set; }
+        #endregion
 
+        #region SearchSettings
+        [Range(1, 5)]
+        [Display(Name = "Search Boost (1-5)", GroupName = Infrastructure.TabNames.SearchSettings,
+            Description = "Boost product in search results with default sort", Order = 1)]
+        public virtual int Boost { get; set; }
+
+        [Display(Name = "Bury", GroupName = Infrastructure.TabNames.SearchSettings,
+            Description = "This will determine whether or not to hide product in search results.", Order = 2)]
+        public virtual bool Bury { get; set; }
         #endregion
 
         #region Manufacturer
@@ -173,6 +182,8 @@ namespace Foundation.Features.CatalogContent.Product
 
             AssociationsTitle = "You May Also Like";
             ProductStatus = "Active";
+            Boost = 1;
+            Bury = false;
         }
 
         //public void SetItem(ItemModel itemModel)

--- a/src/Foundation/Features/Search/FoundationSearchProvider.cs
+++ b/src/Foundation/Features/Search/FoundationSearchProvider.cs
@@ -4,6 +4,7 @@ using EPiServer.Commerce.Catalog.ContentTypes;
 using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.Find;
+using EPiServer.Find.Api;
 using EPiServer.Find.Api.Querying;
 using EPiServer.Find.Cms;
 using EPiServer.Find.Commerce;
@@ -184,6 +185,12 @@ namespace Foundation.Features.Search
                 .GetFilter(new NestedFilterExpression<TSource, TListItem>(nestedExpression, filterExpression, search.Client.Conventions).Expression);
 
             return search.OrFilter(filter);
+        }
+
+        public static ITypeSearch<TSource> ThenByScore<TSource>(this ITypeSearch<TSource> search)
+        {
+            return new Search<TSource, IQuery>(search, context =>
+                context.RequestBody.Sort.Add(new Sorting("_score")));
         }
     }
 }

--- a/src/Foundation/Features/Search/ProductSearchBlock/ProductSearchBlockComponent.cs
+++ b/src/Foundation/Features/Search/ProductSearchBlock/ProductSearchBlockComponent.cs
@@ -270,6 +270,9 @@ namespace Foundation.Features.Search.ProductSearchBlock
                 }
             }
 
+            // Add bury filter
+            filters.Add(new PrefixFilter("Bury$$bool", "false"));
+
             if (productSearchBlock.Filters == null)
             {
                 return filters;

--- a/src/Foundation/Features/Settings/SearchSettings.cs
+++ b/src/Foundation/Features/Settings/SearchSettings.cs
@@ -10,7 +10,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Foundation.Features.Settings
 {
-    [SettingsContentType(DisplayName = "Search Settings",
+    [SettingsContentType(DisplayName = "Search & Catalog Settings",
         GUID = "d4171337-70a4-476a-aa3c-0d976ac185e8",
         SettingsName = "Search Settings")]
     public class SearchSettings : SettingsBase, IFacetConfiguration
@@ -49,6 +49,10 @@ namespace Foundation.Features.Settings
             Order = 300)]
         [EditorDescriptor(EditorDescriptorType = typeof(IgnoreCollectionEditorDescriptor<FacetFilterConfigurationItem>))]
         public virtual IList<FacetFilterConfigurationItem> SearchFiltersConfiguration { get; set; }
+
+        [SelectOne(SelectionFactoryType = typeof(CurrencySelectionFactory))]
+        [Display(Name = "Currency", GroupName = TabNames.SearchSettings, Order = 210)]
+        public virtual string Currency { get; set; }
     }
 
     public class SearchOptionSelectionFactory : ISelectionFactory

--- a/src/Foundation/Infrastructure/Commerce/Models/EditorDescriptors/CurrencySelectionFactory.cs
+++ b/src/Foundation/Infrastructure/Commerce/Models/EditorDescriptors/CurrencySelectionFactory.cs
@@ -4,7 +4,7 @@ using Mediachase.Commerce.Markets;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Foundation.Features.CatalogContent.DynamicCatalogContent.DynamicVariation
+namespace Foundation.Infrastructure.Commerce.Models.EditorDescriptors
 {
     public class CurrencySelectionFactory : ISelectionFactory
     {


### PR DESCRIPTION
Product search enhancements: 
Two new properties added to "Search Settings" tab of Generic Product:
"Bury" -- hide product from search results
"Boost" -- boost product in search results in default sort