### PR TITLE
Checkout page checkbox style fix due to bootstrap changes

### DIFF
--- a/src/Foundation/Features/Checkout/BillingInformation.cshtml
+++ b/src/Foundation/Features/Checkout/BillingInformation.cshtml
@@ -13,7 +13,7 @@
                         {
 
                             <div>
-                                <label class="checkbox">
+                                <label class="checkbox mb-2">
                                     @Html.TranslateFallback("Use shipping address as billing address", "Use shipping address as billing address")
                                     @Html.RadioButtonFor(x => x.BillingAddressType, 2, new { @class = "radio jsBillingAddress" })
                                     <span class="checkmark"></span>
@@ -23,7 +23,7 @@
                         @if (User.Identity.IsAuthenticated)
                         {
                             <div>
-                                <label class="checkbox">
+                                <label class="checkbox mb-2">
                                     @Html.TranslateFallback("/Checkout/Billing/ExistingAddress", "Bill to existing address")
                                     @Html.RadioButtonFor(x => x.BillingAddressType, 1, new
                                {
@@ -34,7 +34,7 @@
                             </div>
                         }
                         <div>
-                            <label class="checkbox">
+                            <label class="checkbox mb-2">
                                 @Html.TranslateFallback("/Checkout/Billing/NewAddress", "Bill to new address")
                                 @Html.RadioButtonFor(x => x.BillingAddressType, 0, new { @class = "radio jsBillingAddress" })
                                 <span class="checkmark"></span>

--- a/src/Foundation/Features/Checkout/SingleAddress.cshtml
+++ b/src/Foundation/Features/Checkout/SingleAddress.cshtml
@@ -15,7 +15,7 @@
                     @if (User.Identity.IsAuthenticated)
                     {
                         <div>
-                            <label class="checkbox">
+                            <label class="checkbox mb-2">
                                 @Html.TranslateFallback("/Checkout/Shipment/ExistingAddress", "Ship to existing address")
                                 @Html.RadioButtonFor(x => x.Shipments[index].ShippingAddressType, 1, new { @class = "radio jsSingleAddress" })
                                 <span class="checkmark"></span>
@@ -24,7 +24,7 @@
                         </div>
                     }
                     <div>
-                        <label class="checkbox">
+                        <label class="checkbox mb-2">
                             @Html.TranslateFallback("/Checkout/Shipment/NewAddress", "Ship to new address")
                             @Html.RadioButtonFor(x => x.Shipments[index].ShippingAddressType, 0, new { @class = "radio jsSingleAddress" })
                             <span class="checkmark"></span>


### PR DESCRIPTION
If there are other instances of checkbox radio buttons overlapping with element below them, add "mb-2" to set margin-bottom to 0.5rem -- https://getbootstrap.com/docs/5.1/utilities/spacing/