### PR TITLE
Temporary fix to keep EPiServer.Net.Cli at version 1.0.0

### DIFF
--- a/setup.cmd
+++ b/setup.cmd
@@ -118,7 +118,10 @@ echo ## Dropping user ##
 echo ## Dropping user ## >> Build\Logs\Database.log
 %sql% -Q "if exists (select loginname from master.dbo.syslogins where name = '%user%') EXEC sp_droplogin @loginame='%user%'" >> Build\Logs\Database.log
 
-dotnet tool update EPiServer.Net.Cli --global --add-source https://nuget.optimizely.com/feed/packages.svc/
+REM Temporary update to force EPiServer.Net.Cli v1.0.0 until more troubleshooting can be done on v2.0.0
+REM dotnet tool update EPiServer.Net.Cli --global --add-source https://nuget.optimizely.com/feed/packages.svc/
+dotnet tool uninstall EPiServer.Net.Cli --global
+dotnet tool install EPiServer.Net.Cli --version 1.0.0 --global --add-source https://nuget.optimizely.com/feed/packages.svc/
 dotnet-episerver create-cms-database ".\src\Foundation\Foundation.csproj" -S "%SQLSERVER%" %ADDITIONAL_SQLCMD%  --database-name "%APPNAME%.Cms"
 dotnet-episerver create-commerce-database ".\src\Foundation\Foundation.csproj" -S "%SQLSERVER%" %ADDITIONAL_SQLCMD%  --database-name "%APPNAME%.Commerce" --reuse-cms-user
 


### PR DESCRIPTION
When EPiServer.Net.Cli is updated to version 2.0.0, it's resulting in initialization errors. This is a temporary workaround to force EPiServer.Net.Cli to version 1.0.0, until the full fix can be investigated and implemented.