### PR TITLE
Ensure thumbnail is generated correctly in the UI

### DIFF
--- a/src/Foundation/Features/Media/ImageMediaData.cs
+++ b/src/Foundation/Features/Media/ImageMediaData.cs
@@ -23,9 +23,6 @@ namespace Foundation.Features.Media
         public virtual Blob LargeThumbnail { get; set; }
 
         [Editable(false)]
-        public override Blob Thumbnail { get => BinaryData; }
-
-        [Editable(false)]
         [Display(Name = "File size", GroupName = SystemTabNames.Content, Order = 20)]
         public virtual string FileSize { get; set; }
 


### PR DESCRIPTION
Do not override the thumbnail property in the standard media to ensure the thumbnail is generated correctly