### PR TITLE
Add odp ma connector

### DIFF
--- a/src/Foundation/Foundation.csproj
+++ b/src/Foundation/Foundation.csproj
@@ -40,6 +40,7 @@
 		<PackageReference Include="Geta.Optimizely.Categories" Version="1.0.0" />
 		<PackageReference Include="Geta.Optimizely.Categories.Find" Version="1.0.0" />
 		<PackageReference Include="NonFactors.Grid.Core.Mvc6" Version="7.0.1" />
+		<PackageReference Include="Optimizely.Labs.MarketingAutomationIntegration.ODP" Version="1.0.2" />
 		<PackageReference Include="Powell.CouponCode" Version="1.0.3" />
 		<PackageReference Include="PowerSlice" Version="5.0.0" />
 		<PackageReference Include="Schema.NET" Version="11.0.1" />

--- a/src/Foundation/Infrastructure/CustomFormsRepository.cs
+++ b/src/Foundation/Infrastructure/CustomFormsRepository.cs
@@ -1,0 +1,73 @@
+using EPiServer.Forms.Core;
+using EPiServer.Forms.Core.Internal.ExternalSystem;
+using Episerver.Marketing.Connector.Forms;
+using Episerver.Marketing.Connector.Forms.Repositories;
+using Episerver.Marketing.Connector.Framework;
+using Episerver.Marketing.Connector.Framework.Data;
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Foundation.Infrastructure;
+
+/*
+ *  Copy this file into your CMS Project and 
+ *  Add the following in Startup.cs if using Marketing Automation Connectors
+ *         services.AddFormRepositoryWorkAround();
+ */
+public class CustomFormsRepository : IFormsRepository
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IFormsRepository _instance;
+
+    public CustomFormsRepository(IServiceProvider serviceProvider, IFormsRepository instance)
+    {
+        _serviceProvider = serviceProvider;
+        _instance = instance;
+    }
+
+    public bool IsAutoFillEnabled()
+    {
+        return _instance.IsAutoFillEnabled();
+    }
+
+    public IEnumerable<string> GetSuggestedFormValues(IDatasource selectedDatasource, IEnumerable<RemoteFieldInfo> remoteFieldInfos,
+        ElementBlockBase content, IFormContainerBlock formContainerBlock, HttpContext context)
+    {
+        if (!IsAutoFillEnabled() || !selectedDatasource.Id.Contains(FormsConstants.DataSourceIdListSeparator))
+            return new List<string>();
+
+        return _instance.GetSuggestedFormValues(selectedDatasource, remoteFieldInfos, content, formContainerBlock,
+            context);
+    }
+
+    public void PushDataToConnector(IMarketingConnector currentConnector, ConnectorDataSource currentDatasource,
+        Dictionary<string, string> entityData, long submissionTarget)
+    {
+        _instance.PushDataToConnector(currentConnector, currentDatasource, entityData, submissionTarget);
+    }
+
+    public Dictionary<string, string> GetConnectorMappedData(IEnumerable<KeyValuePair<string, RemoteFieldInfo>> submittedFieldMappingTable, IDictionary<string, object> submittedData)
+    {
+        return _instance.GetConnectorMappedData(submittedFieldMappingTable, submittedData);
+    }
+
+    public string ConvertGuidToAdaptedGuid(Guid theGuid)
+    {
+        return _instance.ConvertGuidToAdaptedGuid(theGuid);
+    }
+
+    public Guid ConvertAdaptedGuidToGuid(string theAdaptedGuid)
+    {
+        return _instance.ConvertAdaptedGuidToGuid(theAdaptedGuid);
+    }
+}
+
+public static class FormRepositoryHelper
+{
+    public static IServiceCollection AddFormRepositoryWorkAround(this IServiceCollection services)
+    {
+        return services.Intercept<IFormsRepository>((a, b) => new CustomFormsRepository(a, b));
+    }
+} 

--- a/src/Foundation/Resources/Translations/Optimizely.Labs.MarketingAutomationIntegration.ODP.Forms_EN.xml
+++ b/src/Foundation/Resources/Translations/Optimizely.Labs.MarketingAutomationIntegration.ODP.Forms_EN.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--Please copy this lang file into /wwwroot/lang folder-->
+<languages>
+	<language name="English" id="en">
+		<episerver>
+			<forms>
+				<externalsystems>
+					<optimizely.labs.marketingautomationintegration.odp.odpexternalsystem>
+						<displayname>ODP System Database</displayname>
+					</optimizely.labs.marketingautomationintegration.odp.odpexternalsystem>
+				</externalsystems>
+			</forms>
+		</episerver>
+	</language>
+</languages>

--- a/src/Foundation/Startup.cs
+++ b/src/Foundation/Startup.cs
@@ -32,6 +32,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Optimizely.Labs.MarketingAutomationIntegration.ODP;
 using System;
 using System.IO;
 using System.Linq;
@@ -214,6 +215,10 @@ namespace Foundation
             {
                 o.ContentAssetsBasePath = ContentAssetsBasePath.ContentOwner;
             });
+
+            // Add ODP MA Connector (note: requires API key in appsettings.json)
+            services.AddMarketingAutomationIntegrationODP(_configuration);
+            services.AddFormRepositoryWorkAround();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Foundation/Views/Shared/ElementBlocks/ODPListConsentFormBlock.cshtml
+++ b/src/Foundation/Views/Shared/ElementBlocks/ODPListConsentFormBlock.cshtml
@@ -1,0 +1,21 @@
+﻿@model Optimizely.Labs.MarketingAutomationIntegration.ODP.Models.ODPListConsentFormBlock
+@using EPiServer.Forms.Helpers.Internal
+@{
+    var formElement = Model.FormElement;
+    var labelText = Model.Label;
+    var cssClasses = Model.GetValidationCssClasses();
+}
+@using (Html.BeginElement(Model, new { @class = "form-check form-group" + cssClasses, data_f_type = "textbox" }))
+{
+    <input name="@formElement.ElementName"
+           id="@formElement.Guid"
+           type="checkbox"
+           class="form-check-input "
+           aria-describedby="@Util.GetAriaDescribedByElementName(formElement.ElementName)"
+           value="@Model.GetDefaultValue()" @Model.AttributesString
+           data-f-datainput aria-invalid="@Util.GetAriaInvalidByValidationCssClasses(cssClasses)" />
+    <label for="@formElement.Guid" class="Form__Element__Caption form-check-label">
+        @Html.Raw(labelText)
+    </label>
+    @Html.ValidationMessageFor(Model)
+}

--- a/src/Foundation/appsettings.json
+++ b/src/Foundation/appsettings.json
@@ -104,5 +104,10 @@
         "Ratings": "https://change.me/"
       }
     }
+  },
+  "MAIOdpSettings": {
+    "OdpBaseEndPoint": "https://api.zaius.com/",
+    "CustomerObjectName": "customers",
+    "APIKey": "changeme.ODP-private-key"
   }
 }

--- a/src/Foundation/lang/Optimizely.Labs.MarketingAutomationIntegration.ODP.Forms_EN.xml
+++ b/src/Foundation/lang/Optimizely.Labs.MarketingAutomationIntegration.ODP.Forms_EN.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--Please copy this lang file into /wwwroot/lang folder-->
+<languages>
+	<language name="English" id="en">
+		<episerver>
+			<forms>
+				<externalsystems>
+					<optimizely.labs.marketingautomationintegration.odp.odpexternalsystem>
+						<displayname>ODP System Database</displayname>
+					</optimizely.labs.marketingautomationintegration.odp.odpexternalsystem>
+				</externalsystems>
+			</forms>
+		</episerver>
+	</language>
+</languages>


### PR DESCRIPTION
Installing ODP MA Connector to Foundation:

- Optimizely.Labs.MarketingAutomationIntegration.ODP
- https://github.com/optimizely/marketingautomationintegration-odp

Usage notes: 

- To enable, you must enter your ODP Private API Key in the appsettings.json file.
- If using a non-US ODP instance, update the ODP base endpoint in the appsettings.json file accordingly.