### PR TITLE
Fix customer login and credit-card checkout on non-Development environments

### DIFF
--- a/src/Foundation/Features/Checkout/Payments/GenericCreditCardPaymentGateway.cs
+++ b/src/Foundation/Features/Checkout/Payments/GenericCreditCardPaymentGateway.cs
@@ -7,7 +7,10 @@ namespace Foundation.Features.Checkout.Payments
     {
         public PaymentProcessingResult ProcessPayment(IOrderGroup orderGroup, IPayment payment)
         {
-            var creditCardPayment = (ICreditCardPayment)payment;
+            // Commerce 15 removed ICreditCardPayment: GenericCreditCardPaymentOption now creates
+            // a generic IPayment, so casting to the (stubbed) ICreditCardPayment threw
+            // InvalidCastException at runtime and made every credit-card purchase fail.
+            // The cast was dead code — the validation that used it is commented out below.
             return PaymentProcessingResult.CreateSuccessfulResult("");
             //if (creditCardPayment.CreditCardNumber.EndsWith("4"))
             //{

--- a/src/Foundation/Startup.cs
+++ b/src/Foundation/Startup.cs
@@ -70,31 +70,28 @@ namespace Foundation
                 Name = "EcfSqlConnection",
                 ConnectionString = ecfConnStr
             }));
-            // CMS 13: On DXP, Opti ID is mandatory — do NOT call AddCmsAspNetIdentity on non-Development.
-            // AddOptimizelyIdentity is registered below in the non-Development block.
-            if (_webHostingEnvironment.IsDevelopment())
+            // ASP.NET Identity is required in ALL environments: site visitors (demo users,
+            // registration, checkout, my-account pages) sign in with ApplicationSignInManager/
+            // ApplicationUserManager<SiteUser> against AspNetUsers in the Commerce database.
+            // On DXP this coexists with Opti ID: AddOptimizelyIdentity (registered below with
+            // useAsDefault: false) intercepts the authentication schemes ONLY for CMS UI paths
+            // (protected modules, edit/preview context), so editors use Opti ID while site
+            // visitors keep using ASP.NET Identity cookies.
+            // NOTE: previously this was skipped on non-Development and replaced by null-returning
+            // ServiceAccessor stubs, which caused NullReferenceExceptions on customer login
+            // ("Something Went Wrong") and broke profile/order/address pages on deployed sites.
+            services.AddCmsAspNetIdentity<SiteUser>(o =>
             {
-                services.AddCmsAspNetIdentity<SiteUser>(o =>
+                if (string.IsNullOrEmpty(o.ConnectionStringOptions?.ConnectionString))
                 {
-                    if (string.IsNullOrEmpty(o.ConnectionStringOptions?.ConnectionString))
+                    o.ConnectionStringOptions = new ConnectionStringOptions
                     {
-                        o.ConnectionStringOptions = new ConnectionStringOptions
-                        {
-                            Name = "EcfSqlConnection",
-                            ConnectionString = _configuration.GetConnectionString("EcfSqlConnection")
-                        };
-                    }
-                });
-            }
-            else
-            {
-                // AddCmsAspNetIdentity is not called on DXP (Opti ID is used instead).
-                // CustomerService requires ServiceAccessor<ApplicationSignInManager<SiteUser>> and
-                // ServiceAccessor<ApplicationUserManager<SiteUser>> — register null-returning stubs
-                // so the service can be constructed. Callers must guard for null on non-dev.
-                services.AddSingleton<ServiceAccessor<ApplicationSignInManager<SiteUser>>>(_ => () => null);
-                services.AddSingleton<ServiceAccessor<ApplicationUserManager<SiteUser>>>(_ => () => null);
-            }
+                        Name = "EcfSqlConnection",
+                        // ecfConnStr falls back to EPiServerDB (DXP injects only EPiServerDB).
+                        ConnectionString = ecfConnStr
+                    };
+                }
+            });
 
             //UI
             if (_webHostingEnvironment.IsDevelopment())


### PR DESCRIPTION
## Problem

On deployed (non-Development) environments, logging in as any existing site user (e.g. the demo user David Knipe) failed with the generic error page *"Something Went Wrong — Something went wrong when trying to access this resource."* All account pages (profile, order history, addresses) and checkout were equally broken. Completing a purchase with a credit card failed even where login worked.

## Root causes

### 1. ASP.NET Identity was not registered outside Development (`src/Foundation/Startup.cs`)

The upgrade only called `AddCmsAspNetIdentity<SiteUser>()` in Development, on the assumption that Opti ID replaces it on DXP. On other environments it registered null-returning stubs:

```csharp
services.AddSingleton<ServiceAccessor<ApplicationSignInManager<SiteUser>>>(_ => () => null);
services.AddSingleton<ServiceAccessor<ApplicationUserManager<SiteUser>>>(_ => () => null);
```

Consequences on deployed sites:
- `PublicApiController.Login` / `InternalLogin` called `SignInManager().SignInAsync(...)` on **null** → `NullReferenceException` → 500 on every customer login.
- `ProfilePageController`, `OrderHistoryController`, `ResetPasswordController`, `UsersController` and `CheckoutController` constructor-inject `ApplicationSignInManager<SiteUser>` / `ApplicationUserManager<SiteUser>` directly — unresolvable from DI → 500 on profile, orders, addresses and checkout pages.

The assumption was incorrect: `AddOptimizelyIdentity()` (called with `useAsDefault: false`) installs an `IAuthenticationSchemeProvider` decorator that overrides authentication **only for CMS UI paths** (protected modules, edit/preview context) and delegates everything else to the app default. Opti ID (editors) and ASP.NET Identity (site visitors) are designed to coexist.

**Fix:** register `AddCmsAspNetIdentity<SiteUser>` unconditionally (as CMS 12 did), remove the null stubs, and use the existing `EcfSqlConnection` → `EPiServerDB` fallback so it also works on DXP where only `EPiServerDB` is injected. The Opti ID registration is unchanged.

### 2. Credit-card purchases threw `InvalidCastException` (`GenericCreditCardPaymentGateway.cs`)

Commerce 15 removed `ICreditCardPayment`; this branch replaced it with a compile-only stub in `CommerceTypeStubs.cs` that no runtime payment type implements, and changed `GenericCreditCardPaymentOption` to create a generic `IPayment`. The gateway still hard-cast the payment:

```csharp
var creditCardPayment = (ICreditCardPayment)payment; // always throws at runtime
```

This made `cart.ProcessPayments(...)` fail for the default demo payment method, so no credit-card order could ever be placed. The cast result was dead code (the card-number validation using it is commented out).

**Fix:** removed the dead cast; the gateway returns its (already unconditional) successful result.

## Not changed (known Commerce 15 preview gaps, flagged in code)

- Card details are no longer stored on payments (interface removed) — confirmation UI won't show last-4 digits.
- Saved credit cards (`CreditCardService`) remain stubbed out.
- Subscription first-order checkout workflow remains skipped (`OrderGroupWorkflowManager` removed in Commerce 15).

## Verification

`dotnet build -c Release` — succeeds, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)