### PR TITLE
Harden SettingsService for multi-site setups

### DIFF
--- a/src/Foundation/Infrastructure/Cms/Settings/SettingsService.cs
+++ b/src/Foundation/Infrastructure/Cms/Settings/SettingsService.cs
@@ -260,24 +260,44 @@ namespace Foundation.Infrastructure.Cms.Settings
             var children = _contentRepository.GetChildren<SettingsFolder>(GlobalSettingsRoot).ToList();
             foreach (var site in _siteDefinitionRepository.List())
             {
-                var folder = children.Find(x => x.Name.Equals(site.Name, StringComparison.InvariantCultureIgnoreCase));
-                if (folder != null)
+                // Isolate each site: one site's broken settings (or a failing folder
+                // creation) must never abort the mapping of the remaining sites.
+                // Without this, a second site definition could leave the primary site
+                // with no registered settings at all - empty logo/menus/checkout links
+                // with no runtime errors.
+                try
                 {
-                    foreach (var child in _contentRepository.GetChildren<SettingsBase>(folder.ContentLink))
+                    var folder = children.Find(x => x.Name.Equals(site.Name, StringComparison.InvariantCultureIgnoreCase));
+                    if (folder != null)
                     {
-                        UpdateSettings(site.Id, child, false);
-
-                        // add draft (not published version) settings
-                        var darftContentLink = _contentVersionRepository.LoadCommonDraft(child.ContentLink, ContentLanguage.PreferredCulture.Name);
-                        if (darftContentLink != null)
+                        foreach (var child in _contentRepository.GetChildren<SettingsBase>(folder.ContentLink))
                         {
-                            var settingsDraft = _contentRepository.Get<SettingsBase>(darftContentLink.ContentLink);
-                            UpdateSettings(site.Id, settingsDraft, true);
+                            UpdateSettings(site.Id, child, false);
+
+                            // add draft (not published version) settings; a broken draft
+                            // must not prevent the published settings from registering.
+                            try
+                            {
+                                var darftContentLink = _contentVersionRepository.LoadCommonDraft(child.ContentLink, ContentLanguage.PreferredCulture.Name);
+                                if (darftContentLink != null)
+                                {
+                                    var settingsDraft = _contentRepository.Get<SettingsBase>(darftContentLink.ContentLink);
+                                    UpdateSettings(site.Id, settingsDraft, true);
+                                }
+                            }
+                            catch (Exception draftException)
+                            {
+                                _log.Error($"[Settings] Failed loading draft settings '{child.Name}' for site '{site.Name}': {draftException.Message}", exception: draftException);
+                            }
                         }
+                        continue;
                     }
-                    continue;
+                    CreateSiteFolder(site);
                 }
-                CreateSiteFolder(site);
+                catch (Exception siteException)
+                {
+                    _log.Error($"[Settings] Failed mapping settings for site '{site.Name}' ({site.Id}): {siteException.Message}", exception: siteException);
+                }
             }
         }
 
@@ -391,12 +411,18 @@ namespace Foundation.Infrastructure.Cms.Settings
 
             if (e.Content is SettingsBase)
             {
-                var id = ResolveSiteId();
-                if (id == Guid.Empty)
+                // Resolve the OWNING site from the settings folder the item lives in
+                // (same as PublishedContent). Resolving from the editor's request host
+                // filed drafts under whatever site the CMS host resolves to, poisoning
+                // another site's draft settings in multi-site setups.
+                var parent = _contentRepository.Get<IContent>(e.Content.ParentLink);
+                var site = _siteDefinitionRepository.Get(parent.Name);
+                var id = site?.Id;
+                if (id == null || id == Guid.Empty)
                 {
                     return;
                 }
-                UpdateSettings(id, e.Content, true);
+                UpdateSettings(id.Value, e.Content, true);
             }
         }
 
@@ -410,8 +436,19 @@ namespace Foundation.Infrastructure.Cms.Settings
             var site = _siteDefinitionResolver.GetByHostname(request.Host.Host, true, out var hostname);
             if (site == null)
             {
-                // CMS 13: hostname resolution may not match localhost in dev. Fall back to the first registered site.
-                site = _siteDefinitionRepository.List().FirstOrDefault();
+                // Hostname resolution can miss in local dev (localhost not registered
+                // as a host). Only fall back when there is exactly ONE site - with
+                // multiple sites, picking List().First() silently reads ANOTHER site's
+                // (possibly empty) settings and breaks the storefront with no errors.
+                var allSites = _siteDefinitionRepository.List().ToList();
+                if (allSites.Count == 1)
+                {
+                    site = allSites[0];
+                }
+                else
+                {
+                    _log.Warning($"[Settings] Could not resolve a site for host '{request.Host.Host}' among {allSites.Count} sites; returning no settings.");
+                }
             }
             return site?.Id ?? Guid.Empty;
         }


### PR DESCRIPTION
## Problem

Creating a second site definition (for the headless Visual Builder site) broke the main storefront: empty logo and navigation, user menu missing its dashboard/settings entries, checkout button not navigating — **with nothing in the console or Log Stream**. Deleting the site definition and restarting restored everything.

## Root cause

Foundation's settings (logo = `LayoutSettings.SiteLogo`, menus, checkout link = `ReferencePageSettings.CheckoutPage`) are registered per site in `SettingsService`, and the multi-site paths are fragile in three ways:

1. **`UpdateSettings()` (startup mapping loop) has no per-site error isolation.** Any exception while processing one site — e.g. a failing draft load (`LoadCommonDraft`/`Get<SettingsBase>`) on the second site's auto-created settings, or a throwing `CreateSiteFolder` — aborts the whole loop, leaving the remaining sites with **no registered settings at all**. It runs as a first-request initializer, so the only trace is a single startup-time log line; at runtime every lookup just returns default and the views null-coalesce (`referenceSettings?.CheckoutPage ?? ...`) — silent by design.

2. **`ResolveSiteId()` falls back to `List().FirstOrDefault()`** when hostname resolution misses (fallback added in the CMS 13 upgrade for localhost dev). With multiple sites this silently serves *another site's* — possibly auto-created and empty — settings.

3. **`SavedContent` resolves the owning site from the editor's request host** instead of from the settings folder the item lives in (which `PublishedContent` does correctly), filing draft settings under whichever site the CMS host resolves to.

## Fix

- Per-site try/catch in the mapping loop (plus per-child isolation of draft loads) with loud, site-named error logging — one broken site can no longer take out the others.
- `ResolveSiteId` falls back only when **exactly one** site is registered (preserves the localhost-dev intent); a miss with multiple sites logs a warning.
- `SavedContent` resolves the owning site from the parent folder name, mirroring `PublishedContent`.

## Verification

`dotnet build -c Release` — succeeds, 0 errors.

Diagnosed on the Integration environment where the symptoms reproduced deterministically across restarts while the second site definition existed, and disappeared when it was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)