### PR TITLE
Add settings mapping diagnostics and guard demo-login redirect

### DIFF
--- a/src/Foundation/Features/Api/PublicApiController.cs
+++ b/src/Foundation/Features/Api/PublicApiController.cs
@@ -54,7 +54,9 @@ namespace Foundation.Features.Api
             //set tracking cookie
             TrackingCookieManager.SetTrackingCookie(user.Id);
 
-            return Redirect(returnUrl);
+            // Redirect(null/empty) throws ArgumentNullException (surfaces as unhandled
+            // 500s when the endpoint is hit without a returnUrl, e.g. by warmup probes).
+            return Redirect(string.IsNullOrEmpty(returnUrl) ? "~/" : returnUrl);
         }
 
         [HttpPost]

--- a/src/Foundation/Infrastructure/Cms/Settings/SettingsService.cs
+++ b/src/Foundation/Infrastructure/Cms/Settings/SettingsService.cs
@@ -270,9 +270,11 @@ namespace Foundation.Infrastructure.Cms.Settings
                     var folder = children.Find(x => x.Name.Equals(site.Name, StringComparison.InvariantCultureIgnoreCase));
                     if (folder != null)
                     {
+                        var mapped = 0;
                         foreach (var child in _contentRepository.GetChildren<SettingsBase>(folder.ContentLink))
                         {
                             UpdateSettings(site.Id, child, false);
+                            mapped++;
 
                             // add draft (not published version) settings; a broken draft
                             // must not prevent the published settings from registering.
@@ -290,9 +292,17 @@ namespace Foundation.Infrastructure.Cms.Settings
                                 _log.Error($"[Settings] Failed loading draft settings '{child.Name}' for site '{site.Name}': {draftException.Message}", exception: draftException);
                             }
                         }
+
+                        // Success summary at Warning so it always surfaces (the default log
+                        // level filter is Warning). Diagnosing missing-settings incidents has
+                        // repeatedly stalled on "no [Settings] output" being ambiguous between
+                        // a silent success and a never-ran mapping; this line removes that
+                        // ambiguity permanently.
+                        _log.Warning($"[Settings] Mapped {mapped} settings item(s) for site '{site.Name}' ({site.Id}).");
                         continue;
                     }
                     CreateSiteFolder(site);
+                    _log.Warning($"[Settings] No settings folder matched site '{site.Name}' ({site.Id}); created a new folder with default (empty) settings.");
                 }
                 catch (Exception siteException)
                 {


### PR DESCRIPTION
## Why

Follow-up to #983. Diagnosing the multi-site missing-settings incident stalled twice on the same ambiguity: **no `[Settings]` log output** could mean either "mapping succeeded silently" or "mapping never ran" (old pre-#983 build). This PR makes the settings pipeline self-describing and removes a startup exception storm that pollutes Log Stream during warmup.

## Changes

1. **`SettingsService.UpdateSettings`** — per-site success summary at Warning level (the default DXP log filter is `Warning`, so Information would not surface):
   - `[Settings] Mapped N settings item(s) for site 'foundation' (…)` on success
   - `[Settings] No settings folder matched site '…'; created a new folder with default (empty) settings.` when a site gets auto-created empty settings — previously fully silent, and empty-but-present settings are what make these incidents invisible.

   Together with #983's failure logging, every startup now prints exactly one `[Settings]` line per site — silence is no longer ambiguous.

2. **`PublicApiController.Login`** — `Redirect(returnUrl)` with a null/empty `returnUrl` throws `ArgumentNullException` (observed as repeated unhandled 500s from warmup probes at startup). Falls back to `~/`.

## Verification

`dotnet build -c Release` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)